### PR TITLE
Event: CommandInputChangedEvent

### DIFF
--- a/src/main/java/seedu/address/commons/events/ui/CommandInputChangedEvent.java
+++ b/src/main/java/seedu/address/commons/events/ui/CommandInputChangedEvent.java
@@ -1,0 +1,21 @@
+package seedu.address.commons.events.ui;
+
+import seedu.address.commons.events.BaseEvent;
+
+/**
+ * Indicates a change of input in command box
+ * Contains the full string of input in the command box
+ */
+public class CommandInputChangedEvent extends BaseEvent {
+
+    public final String currentInput;
+
+    public CommandInputChangedEvent(String newCurrentInput) {
+        currentInput = newCurrentInput;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName();
+    }
+}

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -7,7 +7,9 @@ import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
+import seedu.address.commons.core.EventsCenter;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.events.ui.CommandInputChangedEvent;
 import seedu.address.commons.events.ui.NewResultAvailableEvent;
 import seedu.address.logic.ListElementPointer;
 import seedu.address.logic.Logic;
@@ -35,6 +37,10 @@ public class CommandBox extends UiPart<Region> {
         this.logic = logic;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+
+        // posts a CommandInputChangedEvent whenever there is a change to the text of the command box.
+        commandTextField.textProperty().addListener((observable, oldInput, newInput) ->
+                EventsCenter.getInstance().post(new CommandInputChangedEvent(newInput)));
         historySnapshot = logic.getHistorySnapshot();
     }
 


### PR DESCRIPTION
This pr aims to introduce a new event `CommandInputChangedEvent`. This will be post on input change in the command box. Event will contain the current text (`currentInput`) in the input (not entered/executed). This will enable us to give user feedback as the user types his commands. 

### Feedback
- Is there a different way to implement this?

## For next week
### Possible Features
- Hints
  - **delete** | _user_index_
  - **add** | _p/phone a/address e/email t/tag_
- Icon change
  - an icon next to command box that will change according to parsed input
  - eg: **+ add** |  _p/phone a/address e/email t/tag_
- Tab Completion
  - current input is constantly parsed to update the next text to put when tab is pressed

Since we need to implement a feature across the components (ie logic, ui, model). Maybe we can each take 1 to implement.

#### TODO:
- [ ] ~testing~ apparently there's no testing for other events?