### PR TITLE
Misc: Add audio/voice.mp3 to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ classes/
 /bin/
 src/main/resources/docs/
 out/
+audio/voice.mp3


### PR DESCRIPTION
`audio/voice.mp3` is generated by the application and should not be committed.