### PR TITLE
Logic: Alias changes

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -237,6 +237,13 @@ Examples:
 `show` (performs the `list` command) +
 * `alias` +
 Lists all your previously defined aliases.
+
+=== Deleting aliases : `unalias`
+
+Deletes a previously defined alias. +
+Format: `unalias ALIAS COMMAND`
+Examples:
+
 * `alias -d show` +
 `show` +
 The `show` command fails as there is no longer such a command.
@@ -260,6 +267,7 @@ There is no need to save manually.
 
 * *Add* `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]...` +
 e.g. `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague`
+* *Alias* `alias [ALIAS COMMAND]`
 * *Clear* : `clear`
 * *Delete* : `delete INDEX` +
 e.g. `delete 3`
@@ -273,4 +281,5 @@ e.g. `find James Jake`
 e.g.`select 2`
 * *History* : `history`
 * *Undo* : `undo`
+* *Unalias* `unalias ALIAS`
 * *Redo* : `redo`

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -58,6 +58,7 @@ Format: `help`
 
 Adds a person to the address book +
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]...`
+Alias: `a`
 
 [TIP]
 A person can have any number of tags (including 0)
@@ -71,11 +72,13 @@ Examples:
 
 Shows a list of all persons in the address book. +
 Format: `list`
+Alias: `l`
 
 === Editing a person : `edit`
 
 Edits an existing person in the address book. +
 Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]...`
+Alias: `e`
 
 ****
 * Edits the person at the specified `INDEX`. The index refers to the index number shown in the last person listing. The index *must be a positive integer* 1, 2, 3, ...
@@ -96,6 +99,7 @@ Edits the name of the 2nd person to be `Betsy Crower` and clears all existing ta
 
 Finds persons whose names contain any of the given keywords. +
 Format: `find PREFIX/KEYWORD [MORE_PREFIX/KEYWORDS...]`
+Alias: `f`
 
 ****
 * The search is case insensitive. e.g `n/hans` will match `Hans`
@@ -120,6 +124,7 @@ Returns any person who's address contains `Blk 100 Street` (case-insensitive). D
 
 Deletes the specified person from the address book. +
 Format: `delete INDEX`
+Alias: `d`
 
 ****
 * Deletes the person at the specified `INDEX`.
@@ -140,6 +145,7 @@ Deletes the 1st person in the results of the `find` command.
 
 Selects the person identified by the index number used in the last person listing. +
 Format: `select INDEX`
+Alias: `s`
 
 ****
 * Selects the person and loads the Google search page the person at the specified `INDEX`.
@@ -171,6 +177,7 @@ Pressing the kbd:[&uarr;] and kbd:[&darr;] arrows will display the previous and 
 
 Restores the address book to the state before the previous _undoable_ command was executed. +
 Format: `undo`
+Alias: `u`
 
 [NOTE]
 ====
@@ -197,6 +204,7 @@ The `undo` command fails as there are no undoable commands executed previously.
 
 Reverses the most recent `undo` command. +
 Format: `redo`
+Alias: `r`
 
 Examples:
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -65,7 +65,4 @@ public class AddCommand extends UndoableCommand {
                 && toAdd.equals(((AddCommand) other).toAdd));
     }
 
-    public String getCommandWord() {
-        return COMMAND_WORD;
-    }
 }

--- a/src/main/java/seedu/address/logic/commands/AliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AliasCommand.java
@@ -10,7 +10,6 @@ public class AliasCommand extends UndoableCommand {
 
     public static final String COMMAND_WORD = "alias";
     public static final String MESSAGE_ADD_SUCCESS = "The alias \"%1$s\" now points to \"%2$s\".";
-    public static final String MESSAGE_DELETE_SUCCESS = "Deleted alias \"%1$s\".";
     public static final String MESSAGE_LIST_SUCCESS = "Aliases:\n%1$s";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Creates or deletes an alias for other commands."
@@ -20,37 +19,22 @@ public class AliasCommand extends UndoableCommand {
 
     private final String alias;
     private final String command;
-    private final Boolean isDelete;
 
     public AliasCommand() {
         this.alias = null;
         this.command = null;
-        this.isDelete = false;
     }
 
     public AliasCommand(String alias, String command) {
         this.alias = alias;
         this.command = command;
-        this.isDelete = false;
-    }
-
-    public AliasCommand(String alias, Boolean isDelete) {
-        this.alias = alias;
-        this.command = null;
-        this.isDelete = isDelete;
     }
 
     @Override
     public CommandResult executeUndoableCommand() {
         Aliases aliases = UserPrefs.getInstance().getAliases();
 
-        if (isDelete) {
-            aliases.removeAlias(alias);
-            return new CommandResult(String.format(MESSAGE_DELETE_SUCCESS, alias));
-        } else if (command != null) {
-            aliases.addAlias(alias, command);
-            return new CommandResult(String.format(MESSAGE_ADD_SUCCESS, alias, command));
-        } else {
+        if (alias == null && command == null) {
             StringBuilder output = new StringBuilder();
 
             for (String alias : aliases.getAllAliases()) {
@@ -59,6 +43,9 @@ public class AliasCommand extends UndoableCommand {
             }
             return new CommandResult(String.format(MESSAGE_LIST_SUCCESS, output));
         }
+
+        aliases.addAlias(alias, command);
+        return new CommandResult(String.format(MESSAGE_ADD_SUCCESS, alias, command));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AliasCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
-import java.util.Map;
-
+import seedu.address.model.Aliases;
 import seedu.address.model.UserPrefs;
 
 /**
@@ -43,18 +42,19 @@ public class AliasCommand extends UndoableCommand {
 
     @Override
     public CommandResult executeUndoableCommand() {
+        Aliases aliases = UserPrefs.getAliases();
+
         if (isDelete) {
-            UserPrefs.deleteAlias(alias);
+            aliases.removeAlias(alias);
             return new CommandResult(String.format(MESSAGE_DELETE_SUCCESS, alias));
         } else if (command != null) {
-            UserPrefs.addAlias(alias, command);
+            aliases.addAlias(alias, command);
             return new CommandResult(String.format(MESSAGE_ADD_SUCCESS, alias, command));
         } else {
             StringBuilder output = new StringBuilder();
 
-            Map<String, String> aliases = UserPrefs.getAliases();
-            for (String alias : aliases.keySet()) {
-                String command = aliases.get(alias);
+            for (String alias : aliases.getAllAliases()) {
+                String command = aliases.getCommand(alias);
                 output.append(String.format("%1$s=%2$s\n", alias, command));
             }
             return new CommandResult(String.format(MESSAGE_LIST_SUCCESS, output));

--- a/src/main/java/seedu/address/logic/commands/AliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AliasCommand.java
@@ -42,7 +42,7 @@ public class AliasCommand extends UndoableCommand {
 
     @Override
     public CommandResult executeUndoableCommand() {
-        Aliases aliases = UserPrefs.getAliases();
+        Aliases aliases = UserPrefs.getInstance().getAliases();
 
         if (isDelete) {
             aliases.removeAlias(alias);

--- a/src/main/java/seedu/address/logic/commands/AliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AliasCommand.java
@@ -69,7 +69,4 @@ public class AliasCommand extends UndoableCommand {
                 && this.command.equals(((AliasCommand) other).command)); // state check
     }
 
-    public String getCommandWord() {
-        return COMMAND_WORD;
-    }
 }

--- a/src/main/java/seedu/address/logic/commands/AliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AliasCommand.java
@@ -12,10 +12,9 @@ public class AliasCommand extends UndoableCommand {
     public static final String MESSAGE_ADD_SUCCESS = "The alias \"%1$s\" now points to \"%2$s\".";
     public static final String MESSAGE_LIST_SUCCESS = "Aliases:\n%1$s";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Creates or deletes an alias for other commands."
-            + "Parameters: [--delete|-d] COMMAND [OLD_COMMAND]\n"
-            + "Example: " + COMMAND_WORD + " create add\n"
-            + "         " + COMMAND_WORD + " --delete create";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Creates an alias for other commands."
+            + "Parameters: [ALIAS COMMAND]\n"
+            + "Example: " + COMMAND_WORD + " create add\n";
 
     private final String alias;
     private final String command;
@@ -52,8 +51,8 @@ public class AliasCommand extends UndoableCommand {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof AliasCommand // instanceof handles nulls
-                && this.alias.equals(((AliasCommand) other).alias) // state check
-                && this.command.equals(((AliasCommand) other).command)); // state check
+                && (this.alias == null || this.alias.equals(((AliasCommand) other).alias)) // state check
+                && (this.command == null || this.command.equals(((AliasCommand) other).command))); // state check
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -19,7 +19,4 @@ public class ClearCommand extends UndoableCommand {
         return new CommandResult(MESSAGE_SUCCESS);
     }
 
-    public String getCommandWord() {
-        return COMMAND_WORD;
-    }
 }

--- a/src/main/java/seedu/address/logic/commands/Command.java
+++ b/src/main/java/seedu/address/logic/commands/Command.java
@@ -15,11 +15,6 @@ public abstract class Command {
     protected UndoRedoStack undoRedoStack;
 
     /**
-     * Returns the keyword used to call the command
-     */
-    public abstract String getCommandWord();
-
-    /**
      * Constructs a feedback message to summarise an operation that displayed a listing of persons.
      *
      * @param displaySize used to generate summary

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -56,7 +56,4 @@ public class DeleteCommand extends UndoableCommand {
                 && this.targetIndex.equals(((DeleteCommand) other).targetIndex)); // state check
     }
 
-    public String getCommandWord() {
-        return COMMAND_WORD;
-    }
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -215,7 +215,4 @@ public class EditCommand extends UndoableCommand {
         }
     }
 
-    public String getCommandWord() {
-        return COMMAND_WORD;
-    }
 }

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -18,7 +18,4 @@ public class ExitCommand extends Command {
         return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT);
     }
 
-    public String getCommandWord() {
-        return COMMAND_WORD;
-    }
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -34,7 +34,4 @@ public class FindCommand extends Command {
                 && this.predicate.equals(((FindCommand) other).predicate)); // state check
     }
 
-    public String getCommandWord() {
-        return COMMAND_WORD;
-    }
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -21,7 +21,4 @@ public class HelpCommand extends Command {
         return new CommandResult(SHOWING_HELP_MESSAGE);
     }
 
-    public String getCommandWord() {
-        return COMMAND_WORD;
-    }
 }

--- a/src/main/java/seedu/address/logic/commands/HistoryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HistoryCommand.java
@@ -36,7 +36,4 @@ public class HistoryCommand extends Command {
         this.history = history;
     }
 
-    public String getCommandWord() {
-        return COMMAND_WORD;
-    }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -18,7 +18,4 @@ public class ListCommand extends Command {
         return new CommandResult(MESSAGE_SUCCESS);
     }
 
-    public String getCommandWord() {
-        return COMMAND_WORD;
-    }
 }

--- a/src/main/java/seedu/address/logic/commands/MusicCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MusicCommand.java
@@ -16,10 +16,6 @@ public class MusicCommand extends Command {
 
     private static MediaPlayer mediaPlayer;
 
-    public String getCommandWord() {
-        return COMMAND_WORD;
-    }
-
     @Override
     public CommandResult execute() {
         int randomNum = 1 + (int) (Math.random() * 1);

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -34,7 +34,4 @@ public class RedoCommand extends Command {
         this.undoRedoStack = undoRedoStack;
     }
 
-    public String getCommandWord() {
-        return COMMAND_WORD;
-    }
 }

--- a/src/main/java/seedu/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemarkCommand.java
@@ -100,8 +100,4 @@ public class RemarkCommand extends UndoableCommand {
         return index.equals(e.index) && remark.equals(e.remark);
     }
 
-    @Override
-    public String getCommandWord() {
-        return this.COMMAND_WORD;
-    }
 }

--- a/src/main/java/seedu/address/logic/commands/SelectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SelectCommand.java
@@ -50,7 +50,4 @@ public class SelectCommand extends Command {
                 && this.targetIndex.equals(((SelectCommand) other).targetIndex)); // state check
     }
 
-    public String getCommandWord() {
-        return COMMAND_WORD;
-    }
 }

--- a/src/main/java/seedu/address/logic/commands/UnaliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnaliasCommand.java
@@ -1,0 +1,47 @@
+package seedu.address.logic.commands;
+
+import java.util.NoSuchElementException;
+
+import seedu.address.model.Aliases;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Creates an alias for other commands.
+ */
+public class UnaliasCommand extends UndoableCommand {
+
+    public static final String COMMAND_WORD = "unalias";
+    public static final String MESSAGE_SUCCESS = "Deleted alias \"%1$s\".";
+    public static final String MESSAGE_NO_SUCH_ALIAS = "Alias \"%1$s\" doesn't exist.";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes an alias previously defined."
+            + "Parameters: ALIAS\n"
+            + "Example: " + COMMAND_WORD + " create\n";
+
+    private final String alias;
+
+    public UnaliasCommand(String alias) {
+        this.alias = alias;
+    }
+
+    @Override
+    public CommandResult executeUndoableCommand() {
+        Aliases aliases = UserPrefs.getInstance().getAliases();
+
+        try {
+            aliases.removeAlias(alias);
+        } catch (NoSuchElementException e) {
+            return new CommandResult(String.format(MESSAGE_NO_SUCH_ALIAS, alias));
+        }
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, alias));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UnaliasCommand // instanceof handles nulls
+                && this.alias.equals(((UnaliasCommand) other).alias)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/UnaliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnaliasCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import java.util.NoSuchElementException;
 
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Aliases;
 import seedu.address.model.UserPrefs;
 
@@ -25,13 +26,13 @@ public class UnaliasCommand extends UndoableCommand {
     }
 
     @Override
-    public CommandResult executeUndoableCommand() {
+    public CommandResult executeUndoableCommand() throws CommandException {
         Aliases aliases = UserPrefs.getInstance().getAliases();
 
         try {
             aliases.removeAlias(alias);
         } catch (NoSuchElementException e) {
-            return new CommandResult(String.format(MESSAGE_NO_SUCH_ALIAS, alias));
+            throw new CommandException(String.format(MESSAGE_NO_SUCH_ALIAS, alias));
         }
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, alias));

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -34,7 +34,4 @@ public class UndoCommand extends Command {
         this.undoRedoStack = undoRedoStack;
     }
 
-    public String getCommandWord() {
-        return COMMAND_WORD;
-    }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.MusicCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.RemarkCommand;
 import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.UnaliasCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -51,6 +52,9 @@ public class AddressBookParser {
 
         case AliasCommand.COMMAND_WORD:
             return new AliasCommandParser().parse(arguments);
+
+        case UnaliasCommand.COMMAND_WORD:
+            return new UnaliasCommandParser().parse(arguments);
 
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AliasCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AliasCommandParser.java
@@ -2,9 +2,6 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import java.util.Optional;
-
-import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.AliasCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -12,8 +9,6 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new AddCommand object
  */
 public class AliasCommandParser implements Parser<AliasCommand> {
-
-    private String command;
 
     /**
      * Parses the given {@code String} of arguments in the context of the AliasCommand
@@ -24,26 +19,20 @@ public class AliasCommandParser implements Parser<AliasCommand> {
     public AliasCommand parse(String arguments) throws ParseException {
         String[] args = arguments.trim().split("\\s+");
 
-        switch(args.length) {
-        case 1:
-            if (args[0].equals("")) {
-                return new AliasCommand();
-            }
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AliasCommand.MESSAGE_USAGE));
-        case 2:
-            if (args[0].equals("-d") || args[0].equals("--delete")) {
-                return new AliasCommand(args[1], true);
-            }
-            String alias = args[0];
-            try {
-                ParserUtil.parseCommand(Optional.ofNullable(args[1])).ifPresent(cmd -> this.command = cmd);
-            } catch (IllegalValueException ive) {
-                throw new ParseException(ive.getMessage(), ive);
-            }
-            return new AliasCommand(alias, command);
-        default:
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AliasCommand.MESSAGE_USAGE));
+        if (args.length == 1 && args[0].equals("")) {
+            return new AliasCommand();
         }
+
+        if (args.length == 2) {
+            String alias = args[0];
+            String command = ParserUtil.parseCommand(args[1]);
+
+            if (command != null) {
+                return new AliasCommand(alias, command);
+            }
+        }
+
+        throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AliasCommand.MESSAGE_USAGE));
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -4,7 +4,9 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -57,6 +59,24 @@ public class ParserUtil {
      * Used for initial separation of command word and args.
      */
     public static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
+
+    private static final Map<String, Ikon> Icons = new HashMap<>();
+    static {
+        Icons.put(MusicCommand.COMMAND_WORD, Feather.FTH_PLAY);
+        Icons.put(AddCommand.COMMAND_WORD, Feather.FTH_PLUS);
+        Icons.put(AliasCommand.COMMAND_WORD, Feather.FTH_LINK);
+        Icons.put(EditCommand.COMMAND_WORD, Feather.FTH_FILE_ADD);
+        Icons.put(SelectCommand.COMMAND_WORD, Feather.FTH_HEAD);
+        Icons.put(DeleteCommand.COMMAND_WORD, Feather.FTH_TRASH);
+        Icons.put(ClearCommand.COMMAND_WORD, Feather.FTH_CROSS);
+        Icons.put(FindCommand.COMMAND_WORD, Feather.FTH_SEARCH);
+        Icons.put(ListCommand.COMMAND_WORD, Feather.FTH_PAPER);
+        Icons.put(HistoryCommand.COMMAND_WORD, Feather.FTH_CLOCK);
+        Icons.put(ExitCommand.COMMAND_WORD, Feather.FTH_POWER);
+        Icons.put(HelpCommand.COMMAND_WORD, Feather.FTH_HELP);
+        Icons.put(UndoCommand.COMMAND_WORD, Feather.FTH_ARROW_LEFT);
+        Icons.put(RedoCommand.COMMAND_WORD, Feather.FTH_ARROW_RIGHT);
+    }
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -120,88 +140,37 @@ public class ParserUtil {
     }
 
     /**
-     * Parses {@code Optional<String> command} and returns itself if it is a valid command, if {@code command}
-     * is present. See header comment of this class regarding the use of {@code Optional} parameters.
+     * Parses {@code String command} and returns itself if it is a valid command.
      */
-    public static Optional<String> parseCommand(Optional<String> command) throws IllegalValueException {
+    public static String parseCommand(String command) {
         requireNonNull(command);
-        if (command.isPresent()) {
-            switch (command.get()) {
-            case AddCommand.COMMAND_WORD:
-            case AliasCommand.COMMAND_WORD:
-            case EditCommand.COMMAND_WORD:
-            case SelectCommand.COMMAND_WORD:
-            case DeleteCommand.COMMAND_WORD:
-            case ClearCommand.COMMAND_WORD:
-            case FindCommand.COMMAND_WORD:
-            case ListCommand.COMMAND_WORD:
-            case HistoryCommand.COMMAND_WORD:
-            case ExitCommand.COMMAND_WORD:
-            case HelpCommand.COMMAND_WORD:
-            case UndoCommand.COMMAND_WORD:
-            case RedoCommand.COMMAND_WORD:
-                return command;
-            default:
-                return Optional.empty();
-            }
+        switch (command) {
+        case AddCommand.COMMAND_WORD:
+        case AliasCommand.COMMAND_WORD:
+        case EditCommand.COMMAND_WORD:
+        case SelectCommand.COMMAND_WORD:
+        case DeleteCommand.COMMAND_WORD:
+        case ClearCommand.COMMAND_WORD:
+        case FindCommand.COMMAND_WORD:
+        case ListCommand.COMMAND_WORD:
+        case HistoryCommand.COMMAND_WORD:
+        case ExitCommand.COMMAND_WORD:
+        case HelpCommand.COMMAND_WORD:
+        case UndoCommand.COMMAND_WORD:
+        case RedoCommand.COMMAND_WORD:
+            return command;
+        default:
+            return null;
         }
-        return Optional.empty();
     }
 
     /**
-     * Parses {@code Optional<String> command} and returns the corresponding {@code Optional<Ikon> icon}
+     * Parses {@code String command} and returns the corresponding {@code Ikon icon}
      * if valid.
      */
-    public static Optional<Ikon> parseIconCode(String command) {
+    public static Ikon parseIconCode(String command) {
         requireNonNull(command);
-
-        switch (command) {
-
-        case MusicCommand.COMMAND_WORD:
-            return Optional.of(Feather.FTH_PLAY);
-
-        case AddCommand.COMMAND_WORD:
-            return Optional.of(Feather.FTH_PLUS);
-
-        case AliasCommand.COMMAND_WORD:
-            return Optional.of(Feather.FTH_LINK);
-
-        case EditCommand.COMMAND_WORD:
-            return Optional.of(Feather.FTH_FILE_ADD);
-
-        case SelectCommand.COMMAND_WORD:
-            return Optional.of(Feather.FTH_HEAD);
-
-        case DeleteCommand.COMMAND_WORD:
-            return Optional.of(Feather.FTH_TRASH);
-
-        case ClearCommand.COMMAND_WORD:
-            return Optional.of(Feather.FTH_CROSS);
-
-        case FindCommand.COMMAND_WORD:
-            return Optional.of(Feather.FTH_SEARCH);
-
-        case ListCommand.COMMAND_WORD:
-            return Optional.of(Feather.FTH_PAPER);
-
-        case HistoryCommand.COMMAND_WORD:
-            return Optional.of(Feather.FTH_CLOCK);
-
-        case ExitCommand.COMMAND_WORD:
-            return Optional.of(Feather.FTH_POWER);
-
-        case HelpCommand.COMMAND_WORD:
-            return Optional.of(Feather.FTH_HELP);
-
-        case UndoCommand.COMMAND_WORD:
-            return Optional.of(Feather.FTH_ARROW_LEFT);
-
-        case RedoCommand.COMMAND_WORD:
-            return Optional.of(Feather.FTH_ARROW_RIGHT);
-
-        default:
-            return Optional.empty();
-        }
+        return Icons.get(command);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -218,7 +218,7 @@ public class ParserUtil {
         String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
 
-        Aliases aliases = UserPrefs.getAliases();
+        Aliases aliases = UserPrefs.getInstance().getAliases();
         String aliasedCommand = aliases.getCommand(commandWord);
         if (aliasedCommand != null) {
             commandWord = aliasedCommand;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -31,6 +31,7 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.MusicCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.UnaliasCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Aliases;
@@ -65,6 +66,7 @@ public class ParserUtil {
         Icons.put(MusicCommand.COMMAND_WORD, Feather.FTH_PLAY);
         Icons.put(AddCommand.COMMAND_WORD, Feather.FTH_PLUS);
         Icons.put(AliasCommand.COMMAND_WORD, Feather.FTH_LINK);
+        Icons.put(UnaliasCommand.COMMAND_WORD, Feather.FTH_CROSS);
         Icons.put(EditCommand.COMMAND_WORD, Feather.FTH_FILE_ADD);
         Icons.put(SelectCommand.COMMAND_WORD, Feather.FTH_HEAD);
         Icons.put(DeleteCommand.COMMAND_WORD, Feather.FTH_TRASH);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -32,6 +31,7 @@ import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Aliases;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
@@ -218,12 +218,12 @@ public class ParserUtil {
         String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
 
-        Map<String, String> aliases = UserPrefs.getAliases();
-        if (aliases != null && aliases.get(commandWord) != null) {
-            commandWord = aliases.get(commandWord);
+        Aliases aliases = UserPrefs.getAliases();
+        String aliasedCommand = aliases.getCommand(commandWord);
+        if (aliasedCommand != null) {
+            commandWord = aliasedCommand;
         }
 
-        String[] ret = {commandWord, arguments};
-        return ret;
+        return new String[] {commandWord, arguments};
     }
 }

--- a/src/main/java/seedu/address/logic/parser/UnaliasCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnaliasCommandParser.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.UnaliasCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteCommand object
+ */
+public class UnaliasCommandParser implements Parser<UnaliasCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteCommand
+     * and returns an DeleteCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public UnaliasCommand parse(String arguments) throws ParseException {
+        String[] args = arguments.trim().split("\\s+");
+
+        if (args.length != 1 || args[0].equals("")) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnaliasCommand.MESSAGE_USAGE));
+        }
+
+        return new UnaliasCommand(args[0]);
+    }
+
+}

--- a/src/main/java/seedu/address/model/Aliases.java
+++ b/src/main/java/seedu/address/model/Aliases.java
@@ -1,0 +1,77 @@
+package seedu.address.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+/**
+ * Map of aliases to their commands
+ */
+public class Aliases {
+
+    private final Map<String, String> map;
+
+    /*
+     * The 'unusual' code block below is an non-static initialization block, sometimes used to avoid duplication
+     * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
+     *
+     * Note that non-static init blocks are not recommended to use. There are other ways to avoid duplication
+     *   among constructors.
+     */
+    {
+        map = new HashMap<String, String>();
+    }
+
+    /**
+     * Returns a set of all aliases
+     */
+    public Set<String> getAllAliases() {
+        return map.keySet();
+    }
+
+    /**
+     * Returns the command linked to a specific alias, or null otherwise.
+     */
+    public String getCommand(String alias) {
+        return map.get(alias);
+    }
+
+    /**
+     * Adds or updates an alias to the map.
+     */
+    public void addAlias(String alias, String command) {
+        map.put(alias, command);
+    }
+
+    /**
+     * Removes an alias from the map.
+     *
+     * @throws NoSuchElementException if no such alias exists
+     */
+    public boolean removeAlias(String alias) throws NoSuchElementException {
+        if (map.remove(alias) == null) {
+            throw new NoSuchElementException();
+        }
+        return true;
+    }
+
+    //// util methods
+
+    @Override
+    public String toString() {
+        return map.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Aliases // instanceof handles nulls
+                && this.map.equals(((Aliases) other).map));
+    }
+
+    @Override
+    public int hashCode() {
+        return map.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/Aliases.java
+++ b/src/main/java/seedu/address/model/Aliases.java
@@ -5,22 +5,36 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.RedoCommand;
+import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.UndoCommand;
+
 /**
  * Map of aliases to their commands
  */
 public class Aliases {
 
-    private final Map<String, String> map;
+    private final Map<String, String> map = new HashMap<>();
 
     /*
-     * The 'unusual' code block below is an non-static initialization block, sometimes used to avoid duplication
-     * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
-     *
-     * Note that non-static init blocks are not recommended to use. There are other ways to avoid duplication
-     *   among constructors.
+     * We initialise the map with aliases for frequently used commands. Users can add other aliases themselves.
      */
     {
-        map = new HashMap<String, String>();
+        map.put("a", AddCommand.COMMAND_WORD);
+        map.put("d", DeleteCommand.COMMAND_WORD);
+        map.put("e", EditCommand.COMMAND_WORD);
+        map.put("f", FindCommand.COMMAND_WORD);
+        map.put("h", HelpCommand.COMMAND_WORD);
+        map.put("l", ListCommand.COMMAND_WORD);
+        map.put("r", RedoCommand.COMMAND_WORD);
+        map.put("s", SelectCommand.COMMAND_WORD);
+        map.put("u", UndoCommand.COMMAND_WORD);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Aliases.java
+++ b/src/main/java/seedu/address/model/Aliases.java
@@ -25,7 +25,7 @@ public class Aliases {
     /*
      * We initialise the map with aliases for frequently used commands. Users can add other aliases themselves.
      */
-    {
+    public Aliases() {
         map.put("a", AddCommand.COMMAND_WORD);
         map.put("d", DeleteCommand.COMMAND_WORD);
         map.put("e", EditCommand.COMMAND_WORD);

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -11,7 +11,7 @@ public class UserPrefs {
 
     private static UserPrefs instance;
 
-    private Aliases aliases = new Aliases();
+    private Aliases aliases;
     private GuiSettings guiSettings;
     private String addressBookFilePath = "data/addressbook.xml";
     private String addressBookName = "MyAddressBook";
@@ -57,6 +57,9 @@ public class UserPrefs {
     }
 
     public Aliases getAliases() {
+        if (aliases == null) {
+            aliases = new Aliases();
+        }
         return aliases;
     }
 

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -1,8 +1,6 @@
 package seedu.address.model;
 
-import java.util.Map;
 import java.util.Objects;
-import java.util.TreeMap;
 
 import seedu.address.commons.core.GuiSettings;
 
@@ -11,21 +9,13 @@ import seedu.address.commons.core.GuiSettings;
  */
 public class UserPrefs {
 
-    private static Map<String, String> aliases;
+    private static Aliases aliases = new Aliases();
     private GuiSettings guiSettings;
     private String addressBookFilePath = "data/addressbook.xml";
     private String addressBookName = "MyAddressBook";
 
     public UserPrefs() {
         this.setGuiSettings(500, 500, 0, 0);
-
-        if (aliases == null) {
-            initialiseAliases();
-        }
-    }
-
-    private static void initialiseAliases() {
-        aliases = new TreeMap<>();
     }
 
     public GuiSettings getGuiSettings() {
@@ -56,16 +46,8 @@ public class UserPrefs {
         this.addressBookName = addressBookName;
     }
 
-    public static Map<String, String> getAliases() {
+    public static Aliases getAliases() {
         return aliases;
-    }
-
-    public static void addAlias(String alias, String command) {
-        aliases.put(alias, command);
-    }
-
-    public static void deleteAlias(String alias) {
-        aliases.remove(alias);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -25,6 +25,9 @@ public class UserPrefs {
     }
 
     public static UserPrefs getInstance() {
+        if (instance == null) {
+            return new UserPrefs();
+        }
         return instance;
     }
 

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -9,13 +9,23 @@ import seedu.address.commons.core.GuiSettings;
  */
 public class UserPrefs {
 
-    private static Aliases aliases = new Aliases();
+    private static UserPrefs instance;
+
+    private Aliases aliases = new Aliases();
     private GuiSettings guiSettings;
     private String addressBookFilePath = "data/addressbook.xml";
     private String addressBookName = "MyAddressBook";
 
     public UserPrefs() {
+        if (instance == null) {
+            instance = this;
+        }
+
         this.setGuiSettings(500, 500, 0, 0);
+    }
+
+    public static UserPrefs getInstance() {
+        return instance;
     }
 
     public GuiSettings getGuiSettings() {
@@ -46,7 +56,7 @@ public class UserPrefs {
         this.addressBookName = addressBookName;
     }
 
-    public static Aliases getAliases() {
+    public Aliases getAliases() {
         return aliases;
     }
 

--- a/src/main/java/seedu/address/ui/CommandBoxIcon.java
+++ b/src/main/java/seedu/address/ui/CommandBoxIcon.java
@@ -3,7 +3,6 @@ package seedu.address.ui;
 import static seedu.address.logic.parser.ParserUtil.parseCommandAndArguments;
 import static seedu.address.logic.parser.ParserUtil.parseIconCode;
 
-import java.util.Optional;
 import java.util.logging.Logger;
 
 import org.kordamp.ikonli.Ikon;
@@ -50,18 +49,17 @@ public class CommandBoxIcon extends UiPart<Region> {
         }
 
         String commandWord = command[0];
+        Ikon iconCode = parseIconCode(commandWord);
 
-        Optional<Ikon> iconCode = parseIconCode(commandWord);
-
-        if (!iconCode.isPresent()) {
+        if (iconCode == null) {
             icon.setVisible(false);
             return;
         }
 
-        icon.iconCodeProperty().set(iconCode.get());
+        icon.iconCodeProperty().set(iconCode);
         icon.setVisible(true);
         logger.info(LogsCenter.getEventHandlingLogMessage(event,
-                "CommandBoxIcon updated to " + iconCode.get().getDescription()));
+                "CommandBoxIcon updated to " + iconCode.getDescription()));
     }
 
 }

--- a/src/test/java/seedu/address/logic/UndoRedoStackTest.java
+++ b/src/test/java/seedu/address/logic/UndoRedoStackTest.java
@@ -237,9 +237,6 @@ public class UndoRedoStackTest {
             return new CommandResult("");
         }
 
-        public String getCommandWord() {
-            return "";
-        }
     }
 
     class DummyUndoableCommand extends UndoableCommand {
@@ -248,8 +245,5 @@ public class UndoRedoStackTest {
             return new CommandResult("");
         }
 
-        public String getCommandWord() {
-            return "";
-        }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AliasCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AliasCommandTest.java
@@ -44,7 +44,7 @@ public class AliasCommandTest {
                 model
         );
 
-        assertTrue(UserPrefs.getAliases().get(LIST_COMMAND_ALIAS) == ListCommand.COMMAND_WORD);
+        assertTrue(UserPrefs.getAliases().getCommand(LIST_COMMAND_ALIAS) == ListCommand.COMMAND_WORD);
     }
 
     @Test
@@ -77,7 +77,7 @@ public class AliasCommandTest {
                 model
         );
 
-        assertNull(UserPrefs.getAliases().get(LIST_COMMAND_ALIAS));
+        assertNull(UserPrefs.getAliases().getCommand(LIST_COMMAND_ALIAS));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/AliasCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AliasCommandTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.UndoRedoStack;
 import seedu.address.logic.parser.AddressBookParser;
+import seedu.address.model.Aliases;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -53,11 +54,20 @@ public class AliasCommandTest {
         Command aliasListCommand = new AliasCommand();
         aliasListCommand.setData(model, new CommandHistory(), new UndoRedoStack());
 
+        Aliases aliases = UserPrefs.getInstance().getAliases();
+
+        StringBuilder string = new StringBuilder("");
+        for (String alias : aliases.getAllAliases()) {
+            string.append(alias);
+            string.append("=");
+            string.append(aliases.getCommand(alias));
+            string.append("\n");
+        }
+
         assertCommandSuccess(
                 aliasListCommand,
                 model,
-                String.format(AliasCommand.MESSAGE_LIST_SUCCESS,
-                        String.format("%1$s=%2$s\n", LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD)),
+                String.format(AliasCommand.MESSAGE_LIST_SUCCESS, string),
                 model
         );
     }

--- a/src/test/java/seedu/address/logic/commands/AliasCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AliasCommandTest.java
@@ -22,7 +22,7 @@ import seedu.address.model.UserPrefs;
  */
 public class AliasCommandTest {
 
-    public static final String LIST_COMMAND_ALIAS = "show";
+    private static final String LIST_COMMAND_ALIAS = "show";
 
     private Model model;
     private AliasCommand aliasCommand;

--- a/src/test/java/seedu/address/logic/commands/AliasCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AliasCommandTest.java
@@ -44,7 +44,7 @@ public class AliasCommandTest {
                 model
         );
 
-        assertTrue(UserPrefs.getAliases().getCommand(LIST_COMMAND_ALIAS) == ListCommand.COMMAND_WORD);
+        assertTrue(UserPrefs.getInstance().getAliases().getCommand(LIST_COMMAND_ALIAS) == ListCommand.COMMAND_WORD);
     }
 
     @Test
@@ -77,7 +77,7 @@ public class AliasCommandTest {
                 model
         );
 
-        assertNull(UserPrefs.getAliases().getCommand(LIST_COMMAND_ALIAS));
+        assertNull(UserPrefs.getInstance().getAliases().getCommand(LIST_COMMAND_ALIAS));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/AliasCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AliasCommandTest.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.commands;
 
-import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -61,23 +60,6 @@ public class AliasCommandTest {
                         String.format("%1$s=%2$s\n", LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD)),
                 model
         );
-    }
-
-    @Test
-    public void execute_alias_deleteSuccess() throws Exception {
-        aliasCommand.execute();
-
-        Command aliasDeleteCommand = new AliasCommand(LIST_COMMAND_ALIAS, true);
-        aliasDeleteCommand.setData(model, new CommandHistory(), new UndoRedoStack());
-
-        assertCommandSuccess(
-                aliasDeleteCommand,
-                model,
-                String.format(AliasCommand.MESSAGE_DELETE_SUCCESS, LIST_COMMAND_ALIAS),
-                model
-        );
-
-        assertNull(UserPrefs.getInstance().getAliases().getCommand(LIST_COMMAND_ALIAS));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.commands;
 
-import static org.junit.Assert.assertEquals;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
@@ -33,11 +32,5 @@ public class ClearCommandTest {
         ClearCommand command = new ClearCommand();
         command.setData(model, new CommandHistory(), new UndoRedoStack());
         return command;
-    }
-
-    @Test
-    public void get_commandWord() {
-        ClearCommand command = new ClearCommand();
-        assertEquals(command.getCommandWord(), ClearCommand.COMMAND_WORD);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -112,12 +112,6 @@ public class FindCommandTest {
         assertCommandSuccess(command, expectedMessage, Arrays.asList());
     }
 
-    @Test
-    public void get_commandWord() {
-        FindCommand command = prepareCommand("stub");
-        assertEquals(command.getCommandWord(), FindCommand.COMMAND_WORD);
-    }
-
     /**
      * Parses {@code userInput} into a {@code FindCommand}.
      */

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.commands;
 
-import static org.junit.Assert.assertEquals;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showFirstPersonOnly;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -41,10 +40,5 @@ public class ListCommandTest {
     public void execute_listIsFiltered_showsEverything() {
         showFirstPersonOnly(model);
         assertCommandSuccess(listCommand, model, ListCommand.MESSAGE_SUCCESS, expectedModel);
-    }
-
-    @Test
-    public void get_commandWord() {
-        assertEquals(listCommand.getCommandWord(), ListCommand.COMMAND_WORD);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/RemarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemarkCommandTest.java
@@ -49,12 +49,6 @@ public class RemarkCommandTest {
     }
 
     @Test
-    public void get_commandWord() {
-        RemarkCommand standardCommand = new RemarkCommand(INDEX_FIRST_PERSON, new Remark(VALID_REMARK_AMY));
-        assertEquals(standardCommand.getCommandWord(), RemarkCommand.COMMAND_WORD);
-    }
-
-    @Test
     public void generate_successMessage() {
         RemarkCommand standardCommand = new RemarkCommand(INDEX_FIRST_PERSON, new Remark(VALID_REMARK_AMY));
         RemarkCommand deleteCommand = new RemarkCommand(INDEX_FIRST_PERSON, new Remark(""));

--- a/src/test/java/seedu/address/logic/commands/UnaliasCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnaliasCommandTest.java
@@ -48,14 +48,14 @@ public class UnaliasCommandTest {
     }
 
     @Test
-    public void execute_invalidAlias_throwsNoSuchElementException() throws Exception {
-        UnaliasCommand unaliasCommand = new UnaliasCommand(LIST_COMMAND_ALIAS);
+    public void execute_invalidAlias_fails() throws Exception {
+        UnaliasCommand unaliasCommand = new UnaliasCommand("invalid-alias");
         unaliasCommand.setData(model, new CommandHistory(), new UndoRedoStack());
 
         assertCommandFailure(
                 unaliasCommand,
                 model,
-                String.format(UnaliasCommand.MESSAGE_NO_SUCH_ALIAS, LIST_COMMAND_ALIAS)
+                String.format(UnaliasCommand.MESSAGE_NO_SUCH_ALIAS, "invalid-alias")
         );
     }
 

--- a/src/test/java/seedu/address/logic/commands/UnaliasCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnaliasCommandTest.java
@@ -1,0 +1,85 @@
+package seedu.address.logic.commands;
+
+import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.UndoRedoStack;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for {@code UnaliasCommand}.
+ */
+public class UnaliasCommandTest {
+
+    private static final String LIST_COMMAND_ALIAS = "show";
+
+    private Model model;
+
+    @Before
+    public void setUp() {
+        UserPrefs userPrefs = new UserPrefs();
+        userPrefs.getAliases().addAlias(LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD);
+        model = new ModelManager(getTypicalAddressBook(), userPrefs);
+    }
+
+    @Test
+    public void execute_validAlias_success() throws Exception {
+        UnaliasCommand unaliasCommand = new UnaliasCommand(LIST_COMMAND_ALIAS);
+        unaliasCommand.setData(model, new CommandHistory(), new UndoRedoStack());
+
+        assertCommandSuccess(
+                unaliasCommand,
+                model,
+                String.format(UnaliasCommand.MESSAGE_SUCCESS, LIST_COMMAND_ALIAS),
+                model
+        );
+
+        assertNull(UserPrefs.getInstance().getAliases().getCommand(LIST_COMMAND_ALIAS));
+    }
+
+    @Test
+    public void execute_invalidAlias_throwsNoSuchElementException() throws Exception {
+        UnaliasCommand unaliasCommand = new UnaliasCommand(LIST_COMMAND_ALIAS);
+        unaliasCommand.setData(model, new CommandHistory(), new UndoRedoStack());
+
+        assertCommandFailure(
+                unaliasCommand,
+                model,
+                String.format(UnaliasCommand.MESSAGE_NO_SUCH_ALIAS, LIST_COMMAND_ALIAS)
+        );
+    }
+
+    @Test
+    public void equals() {
+        UnaliasCommand unaliasCommand = new UnaliasCommand(LIST_COMMAND_ALIAS);
+        unaliasCommand.setData(model, new CommandHistory(), new UndoRedoStack());
+
+        // same object -> returns true
+        assertTrue(unaliasCommand.equals(unaliasCommand));
+
+        // same values -> returns true
+        UnaliasCommand unaliasCommandCopy = new UnaliasCommand(LIST_COMMAND_ALIAS);
+        assertTrue(unaliasCommand.equals(unaliasCommandCopy));
+
+        // different types -> returns false
+        assertFalse(unaliasCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(unaliasCommand.equals(null));
+
+        // different values -> returns false
+        UnaliasCommand unaliasCommandOther = new UnaliasCommand(LIST_COMMAND_ALIAS + "2");
+        assertFalse(unaliasCommand.equals(unaliasCommandOther));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/UndoableCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoableCommandTest.java
@@ -64,8 +64,5 @@ public class UndoableCommandTest {
             return new CommandResult("");
         }
 
-        public String getCommandWord() {
-            return "";
-        }
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -30,13 +30,13 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.RemarkCommand;
 import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.UnaliasCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonContainsFieldsPredicate;
 import seedu.address.model.person.Remark;
-
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -66,6 +66,13 @@ public class AddressBookParserTest {
         AliasCommand command = (AliasCommand) parser.parseCommand(
                 AliasCommand.COMMAND_WORD + " show " + ListCommand.COMMAND_WORD);
         assertEquals(new AliasCommand("show", ListCommand.COMMAND_WORD), command);
+    }
+
+    @Test
+    public void parseCommand_unalias() throws Exception {
+        UnaliasCommand command = (UnaliasCommand) parser.parseCommand(
+                UnaliasCommand.COMMAND_WORD + " show");
+        assertEquals(new UnaliasCommand("show"), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AliasCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AliasCommandParserTest.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.AliasCommand;
+import seedu.address.logic.commands.ListCommand;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for {@code AliasCommand}.
+ */
+public class AliasCommandParserTest {
+
+    private static final String LIST_COMMAND_ALIAS = "show";
+
+    private AliasCommandParser parser = new AliasCommandParser();
+
+    @Test
+    public void parse_noArgs_returnsAliasListCommand() {
+        assertParseSuccess(parser, "", new AliasCommand());
+    }
+
+    @Test
+    public void parse_validArgs_returnsAliasCommand() {
+        assertParseSuccess(parser, LIST_COMMAND_ALIAS + " " + ListCommand.COMMAND_WORD,
+                new AliasCommand(LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, AliasCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -41,6 +42,8 @@ public class ParserUtilTest {
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
+
+    private static final String LIST_COMMAND_ALIAS = "show";
 
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
@@ -194,33 +197,26 @@ public class ParserUtilTest {
 
     @Test
     public void parseCommand_validCommand_returnsCommand() throws Exception {
-        assertEquals(ParserUtil.parseCommand(Optional.of(AddCommand.COMMAND_WORD)),
-                Optional.of(AddCommand.COMMAND_WORD));
-        assertEquals(ParserUtil.parseCommand(Optional.of(ListCommand.COMMAND_WORD)),
-                Optional.of(ListCommand.COMMAND_WORD));
+        assertEquals(ParserUtil.parseCommand(AddCommand.COMMAND_WORD), AddCommand.COMMAND_WORD);
+        assertEquals(ParserUtil.parseCommand(ListCommand.COMMAND_WORD), ListCommand.COMMAND_WORD);
     }
 
     @Test
-    public void parseCommand_invalidCommand_returnsEmptyOptional() throws Exception {
-        assertFalse(ParserUtil.parseCommand(Optional.of("")).isPresent());
-        assertFalse(ParserUtil.parseCommand(Optional.of("invalid-command")).isPresent());
-    }
-
-    @Test
-    public void parseCommand_emptyCommand_returnsEmptyOptional() throws Exception {
-        assertFalse(ParserUtil.parseCommand(Optional.empty()).isPresent());
+    public void parseCommand_invalidCommand_returnsNull() throws Exception {
+        assertNull(ParserUtil.parseCommand(""));
+        assertNull(ParserUtil.parseCommand("invalid-command"));
     }
 
     @Test
     public void parseIconCode_validCommand_returnsCorrectIcon() throws Exception {
-        assertEquals(ParserUtil.parseIconCode(AddCommand.COMMAND_WORD).get(), Feather.FTH_PLUS);
-        assertEquals(ParserUtil.parseIconCode(ListCommand.COMMAND_WORD).get(), Feather.FTH_PAPER);
+        assertEquals(ParserUtil.parseIconCode(AddCommand.COMMAND_WORD), Feather.FTH_PLUS);
+        assertEquals(ParserUtil.parseIconCode(ListCommand.COMMAND_WORD), Feather.FTH_PAPER);
     }
 
     @Test
     public void parseIconCode_invalidCommand_returnsEmptyOptional() throws Exception {
-        assertFalse(ParserUtil.parseIconCode("").isPresent());
-        assertFalse(ParserUtil.parseIconCode("invalid-command").isPresent());
+        assertNull(ParserUtil.parseIconCode(""));
+        assertNull(ParserUtil.parseIconCode("invalid-command"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/UnaliasCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnaliasCommandParserTest.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.UnaliasCommand;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for {@code AliasCommand}.
+ */
+public class UnaliasCommandParserTest {
+
+    private static final String LIST_COMMAND_ALIAS = "show";
+
+    private UnaliasCommandParser parser = new UnaliasCommandParser();
+
+    @Test
+    public void parse_validAlias_returnsUnaliasCommand() {
+        assertParseSuccess(parser, LIST_COMMAND_ALIAS, new UnaliasCommand(LIST_COMMAND_ALIAS));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "two arguments",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnaliasCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/model/AliasesTest.java
+++ b/src/test/java/seedu/address/model/AliasesTest.java
@@ -1,0 +1,19 @@
+package seedu.address.model;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.address.model.tag.UniqueTagList;
+
+public class UniqueTagListTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void asObservableList_modifyList_throwsUnsupportedOperationException() {
+        UniqueTagList uniqueTagList = new UniqueTagList();
+        thrown.expect(UnsupportedOperationException.class);
+        uniqueTagList.asObservableList().remove(0);
+    }
+}

--- a/src/test/java/seedu/address/model/AliasesTest.java
+++ b/src/test/java/seedu/address/model/AliasesTest.java
@@ -5,9 +5,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
+import java.util.HashSet;
 import java.util.NoSuchElementException;
-import java.util.TreeSet;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -33,12 +33,14 @@ public class AliasesTest {
 
     @Test
     public void getAllAliases_withAliases_returnsAllAliases() {
-        assertEquals(new TreeSet<String>(), aliases.getAllAliases());
+        Set<String> allAliases = new HashSet<>(aliases.getAllAliases());
 
         aliases.addAlias(LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD);
         aliases.addAlias(ADD_COMMAND_ALIAS, AddCommand.COMMAND_WORD);
-        assertEquals(new TreeSet<String>(
-                Arrays.asList(LIST_COMMAND_ALIAS, ADD_COMMAND_ALIAS)), aliases.getAllAliases());
+        allAliases.add(LIST_COMMAND_ALIAS);
+        allAliases.add(ADD_COMMAND_ALIAS);
+
+        assertEquals(allAliases, aliases.getAllAliases());
     }
 
     @Test
@@ -60,9 +62,13 @@ public class AliasesTest {
 
     @Test
     public void removeAlias_validCommand_removesAlias() {
+        Set<String> allAliases = aliases.getAllAliases();
         aliases.addAlias(LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD);
+
         assertEquals(true, aliases.removeAlias(LIST_COMMAND_ALIAS));
-        assertEquals(new TreeSet<String>(), aliases.getAllAliases());
+        allAliases.remove(LIST_COMMAND_ALIAS);
+
+        assertEquals(allAliases, aliases.getAllAliases());
     }
 
     @Test
@@ -72,14 +78,20 @@ public class AliasesTest {
     }
 
     @Test
-    public void toString_emptyAliases_returnsEmptySet() {
-        assertEquals("{}", aliases.toString());
-    }
-
-    @Test
     public void toString_withAliases_returnsCorrectString() {
         aliases.addAlias(LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD);
-        assertEquals("{" + LIST_COMMAND_ALIAS + "=" + ListCommand.COMMAND_WORD + "}", aliases.toString());
+
+        StringBuilder string = new StringBuilder("{");
+        for (String alias : aliases.getAllAliases()) {
+            string.append(alias);
+            string.append("=");
+            string.append(aliases.getCommand(alias));
+            string.append(", ");
+        }
+        string.delete(string.length() - 2, string.length());
+        string.append("}");
+
+        assertEquals(string.toString(), aliases.toString());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/AliasesTest.java
+++ b/src/test/java/seedu/address/model/AliasesTest.java
@@ -37,7 +37,8 @@ public class AliasesTest {
 
         aliases.addAlias(LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD);
         aliases.addAlias(ADD_COMMAND_ALIAS, AddCommand.COMMAND_WORD);
-        assertEquals(new TreeSet<String>(Arrays.asList(LIST_COMMAND_ALIAS, ADD_COMMAND_ALIAS)), aliases.getAllAliases());
+        assertEquals(new TreeSet<String>(
+                Arrays.asList(LIST_COMMAND_ALIAS, ADD_COMMAND_ALIAS)), aliases.getAllAliases());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/AliasesTest.java
+++ b/src/test/java/seedu/address/model/AliasesTest.java
@@ -1,19 +1,114 @@
 package seedu.address.model;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+import java.util.TreeSet;
+
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import seedu.address.model.tag.UniqueTagList;
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ListCommand;
 
-public class UniqueTagListTest {
+public class AliasesTest {
+    private static final String LIST_COMMAND_ALIAS = "show";
+    private static final String ADD_COMMAND_ALIAS = "create";
+
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
+    private Aliases aliases;
+
+    @Before
+    public void setUp() {
+        aliases = new Aliases();
+    }
+
     @Test
-    public void asObservableList_modifyList_throwsUnsupportedOperationException() {
-        UniqueTagList uniqueTagList = new UniqueTagList();
-        thrown.expect(UnsupportedOperationException.class);
-        uniqueTagList.asObservableList().remove(0);
+    public void getAllAliases_withAliases_returnsAllAliases() {
+        assertEquals(new TreeSet<String>(), aliases.getAllAliases());
+
+        aliases.addAlias(LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD);
+        aliases.addAlias(ADD_COMMAND_ALIAS, AddCommand.COMMAND_WORD);
+        assertEquals(new TreeSet<String>(Arrays.asList(LIST_COMMAND_ALIAS, ADD_COMMAND_ALIAS)), aliases.getAllAliases());
+    }
+
+    @Test
+    public void getCommand_validCommand_returnsCorrectCommand() {
+        aliases.addAlias(LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD);
+        assertEquals(ListCommand.COMMAND_WORD, aliases.getCommand(LIST_COMMAND_ALIAS));
+    }
+
+    @Test
+    public void getCommand_invalidCommand_returnsNull() {
+        assertNull(aliases.getCommand(LIST_COMMAND_ALIAS));
+    }
+
+    @Test
+    public void addCommand_validCommand_addsCorrectAlias() {
+        aliases.addAlias(LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD);
+        assertEquals(ListCommand.COMMAND_WORD, aliases.getCommand(LIST_COMMAND_ALIAS));
+    }
+
+    @Test
+    public void removeAlias_validCommand_removesAlias() {
+        aliases.addAlias(LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD);
+        assertEquals(true, aliases.removeAlias(LIST_COMMAND_ALIAS));
+        assertEquals(new TreeSet<String>(), aliases.getAllAliases());
+    }
+
+    @Test
+    public void removeAlias_invalidCommand_throwsNoSuchElementException() {
+        thrown.expect(NoSuchElementException.class);
+        aliases.removeAlias(LIST_COMMAND_ALIAS);
+    }
+
+    @Test
+    public void toString_emptyAliases_returnsEmptySet() {
+        assertEquals("{}", aliases.toString());
+    }
+
+    @Test
+    public void toString_withAliases_returnsCorrectString() {
+        aliases.addAlias(LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD);
+        assertEquals("{" + LIST_COMMAND_ALIAS + "=" + ListCommand.COMMAND_WORD + "}", aliases.toString());
+    }
+
+    @Test
+    public void equals_sameSet_returnsTrue() {
+        Aliases other = new Aliases();
+        assertTrue(aliases.equals(other));
+
+        aliases.addAlias(LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD);
+        other.addAlias(LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD);
+
+        assertTrue(aliases.equals(other));
+    }
+
+    @Test
+    public void equals_differentSet_returnsFalse() {
+        Aliases other = new Aliases();
+
+        aliases.addAlias(LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD);
+
+        assertFalse(aliases.equals(other));
+    }
+
+    @Test
+    public void hashCode_sameSet_returnsSameHashCode() {
+        Aliases expectedAliases = new Aliases();
+        assertEquals(aliases.hashCode(), expectedAliases.hashCode());
+
+        aliases.addAlias(LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD);
+        expectedAliases.addAlias(LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD);
+
+        assertEquals(aliases.hashCode(), expectedAliases.hashCode());
     }
 }


### PR DESCRIPTION
This PR refactors the alias feature and adds sane default aliases.
e.g. `a` -> `add`, `d` -> `delete`, etc.

It also splits `alias -d` into a new command, `unalias`. The rationale is that using command flags was inconsistent with other commands, such as the `add` and `delete` pair.

### Notable changes
UserPrefs is now a Singleton.

### Moving forward
Should we remind users that there are aliases if they use the full command? A similar feature for the `zsh` shell is [alias-tips](https://github.com/djui/alias-tips).
e.g. `list` -> `Alias tip: l`