### PR TITLE
Logic: Find by Remark

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -367,7 +367,8 @@ Unify offers users the option to find people by their details. To implement the 
 `key` contains the detail's prefix and `value` contains the keywords that succeed that prefix.
 
 For each detail, there are specific `Predicates` that are defined. They are `AddressContainsKeywordPredicate`, `EmailContainsKeywordPredicate`,
-`NameContainsKeywordPredicate`, `PhoneContainsKeywordPredicate` and `TagsContainKeywordPredicate`. The implementation for `Predicate#test` is as follows:
+`NameContainsKeywordPredicate`, `PhoneContainsKeywordPredicate` and `TagsContainKeywordPredicate`, `RemarkContainsKeywordPredicate`. The implementation is as follows:
+
 [source,java]
 ----
 public class DetailContainsKeywordPredicate implements Predicate<ReadOnlyPerson> {
@@ -386,12 +387,14 @@ public class DetailContainsKeywordPredicate implements Predicate<ReadOnlyPerson>
 
 ----
 [NOTE]
-For Tags, we test for all tags and check for at least one `String#contains` match.
+For Tags, we test for all tags and check for at least one `String#contains` match. For Remark, we check using `StringUtil#containsWordIgnoreCase`.
+
 
 However, just having a specific `Predicate` for each detail is insufficient as `ModelManager#updateFilteredPersonList()`
 only takes only a single `Predicate` as an argument.
 As such, to accept multiple details in one query, we need to encapsulate multiple `Predicates` into one `Predicate`.
 This is encapsulated by `PersonContainsFieldsPredicate` which takes in a list of `Predicates` as an argument.
+
 Internally, the `Predicates` are stored in a `HashSet`.
 
 [source,java]

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -185,14 +185,17 @@ image:UG_FindByNameOutput.png[width="300"] +
 * Words will be matched if the keyword is contained by the peron's details e.g. `n/Han` will identify `Hans`, `n/Gabrielle` will not identify `Gabriel`.
 ****
 
+[NOTE]
+For Remark, we test with `StringUtil#containsWordIgnoreCase` which is case-insensitive but a full match is required
+
 Examples:
 
 * `find n/John` +
 Returns `john` and `John Doe`
 * `find n/John t/friend p/123` +
-Returns any person who's name contains `john`, has a tag which contains `friend` and who's phone contains `123`.
+Returns any person whose name contains `john`, has a tag which contains `friend` and whose phone contains `123`.
 * `find a/Blk 100 Street` +
-Returns any person who's address contains `Blk 100 Street` (case-insensitive). Does not return person who's address is `Street Blk 100`.
+Returns any person whose address contains `Blk 100 Street` (case-insensitive). Does not return person whose address is `Street Blk 100`.
 
 TIP: You may also click on tags to do a search for that tag. (ie. find t/CLICKED_TAG); +
 Clicking on a tag, image:UG_ClickTagInput.png[width="300"] +

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.ArrayList;
@@ -19,12 +20,14 @@ import seedu.address.model.person.EmailContainsKeywordPredicate;
 import seedu.address.model.person.NameContainsKeywordPredicate;
 import seedu.address.model.person.PersonContainsFieldsPredicate;
 import seedu.address.model.person.PhoneContainsKeywordPredicate;
+import seedu.address.model.person.RemarkContainsKeywordPredicate;
 import seedu.address.model.person.TagsContainKeywordPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
  */
 public class FindCommandParser implements Parser<FindCommand> {
+
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns an FindCommand object for execution.
@@ -52,7 +55,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         String formattedText = " " + trimmedArgs;
         ArgumentMultimap argumentMultimap =
                 ArgumentTokenizer.tokenize(formattedText,
-                        PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+                        PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG, PREFIX_REMARK);
 
         List<Predicate> predicateList = new ArrayList<>();
 
@@ -85,6 +88,8 @@ public class FindCommandParser implements Parser<FindCommand> {
             return new TagsContainKeywordPredicate(value);
         case CliSyntax.PREFIX_EMPTY_STRING:
             return new NameContainsKeywordPredicate(value);
+        case CliSyntax.PREFIX_REMARK_STRING:
+            return new RemarkContainsKeywordPredicate(value);
         default:
             return new NameContainsKeywordPredicate(value);
         }

--- a/src/main/java/seedu/address/logic/parser/HintParser.java
+++ b/src/main/java/seedu/address/logic/parser/HintParser.java
@@ -246,12 +246,12 @@ public class HintParser {
      * returns a hint specific to the find command
      */
     private static String generateFindHint() {
-        Optional<String> endHintOptional = generatePrefixHintBasedOnEndArgs(PREFIX_EMPTY, PREFIX_REMARK);
+        Optional<String> endHintOptional = generatePrefixHintBasedOnEndArgs(PREFIX_EMPTY);
 
         if (endHintOptional.isPresent()) {
             return endHintOptional.get();
         }
-        return offerHint("prefix/KEYWORD", PREFIX_EMPTY, PREFIX_REMARK);
+        return offerHint("prefix/KEYWORD", PREFIX_EMPTY);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/RemarkContainsKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/person/RemarkContainsKeywordPredicate.java
@@ -1,0 +1,33 @@
+package seedu.address.model.person;
+
+import static seedu.address.commons.util.StringUtil.containsWordIgnoreCase;
+
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code ReadOnlyPerson}'s {@code remark} contains the keyword given.
+ */
+public class RemarkContainsKeywordPredicate implements Predicate<ReadOnlyPerson> {
+
+    private final String keyword;
+    public RemarkContainsKeywordPredicate(String keyword) {
+        this.keyword = keyword;
+    }
+
+    @Override
+    public boolean test(ReadOnlyPerson person) {
+        return containsWordIgnoreCase(person.getRemark().value, keyword);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof RemarkContainsKeywordPredicate // instanceof handles nulls
+                && this.keyword.equals(((RemarkContainsKeywordPredicate) other).keyword)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return keyword.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/person/TagsContainKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagsContainKeywordPredicate.java
@@ -28,7 +28,7 @@ public class TagsContainKeywordPredicate implements Predicate<ReadOnlyPerson> {
      * Returns true if person's tags list contains keyword (case insensitive)
      */
     private boolean personTagsContainKeyword(ReadOnlyPerson person, String keyword) {
-        return person.getTags().stream().anyMatch(tag -> tag.tagName.contains(keyword));
+        return person.getTags().stream().anyMatch(tag -> tag.tagName.toLowerCase().contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -17,6 +17,7 @@ import seedu.address.model.person.EmailContainsKeywordPredicate;
 import seedu.address.model.person.NameContainsKeywordPredicate;
 import seedu.address.model.person.PersonContainsFieldsPredicate;
 import seedu.address.model.person.PhoneContainsKeywordPredicate;
+import seedu.address.model.person.RemarkContainsKeywordPredicate;
 import seedu.address.model.person.TagsContainKeywordPredicate;
 
 public class FindCommandParserTest {
@@ -37,13 +38,14 @@ public class FindCommandParserTest {
                                         new TagsContainKeywordPredicate("friend"),
                                         new PhoneContainsKeywordPredicate("111"),
                                         new AddressContainsKeywordPredicate("Big Road"),
-                                        new EmailContainsKeywordPredicate("email@email.com"))));
+                                        new EmailContainsKeywordPredicate("email@email.com"),
+                                        new RemarkContainsKeywordPredicate("likes"))));
 
-        assertParseSuccess(parser, "n/Alice t/friend a/Big Road e/email@email.com p/111", expectedFindCommand);
+        assertParseSuccess(parser, "n/Alice t/friend a/Big Road e/email@email.com p/111 r/likes", expectedFindCommand);
 
         // multiple whitespaces between keywords
         assertParseSuccess(parser,
-                " \n n/Alice a/Big Road\n  \ne/email@email.com\t t/friend   p/111\t", expectedFindCommand);
+                " \n n/Alice a/Big Road\n \r\nr/likes \ne/email@email.com\t t/friend   p/111\t", expectedFindCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/HintParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/HintParserTest.java
@@ -106,6 +106,10 @@ public class HintParserTest {
         assertHintEquals("find t/", "TAG");
         assertHintEquals("find t/1", " n/NAME");
 
+        assertHintEquals("find r", "/REMARK");
+        assertHintEquals("find r/", "REMARK");
+        assertHintEquals("find r/a", " n/NAME");
+
 
     }
 

--- a/src/test/java/seedu/address/model/person/AddressContainsKeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/AddressContainsKeywordPredicateTest.java
@@ -35,7 +35,7 @@ public class AddressContainsKeywordPredicateTest {
     }
 
     @Test
-    public void test_nameContainsKeywords_returnsTrue() {
+    public void test_containsKeywords_returnsTrue() {
         // One keyword
         AddressContainsKeywordPredicate predicate = new AddressContainsKeywordPredicate("Blk 101 Address");
         assertTrue(predicate.test(new PersonBuilder().withAddress("Blk 101 Address").build()));
@@ -50,7 +50,7 @@ public class AddressContainsKeywordPredicateTest {
     }
 
     @Test
-    public void test_nameDoesNotContainKeywords_returnsFalse() {
+    public void test_doesNotContainKeywords_returnsFalse() {
 
         AddressContainsKeywordPredicate predicate = new AddressContainsKeywordPredicate("Different Address");
         assertFalse(predicate.test(new PersonBuilder().withAddress("Blk 101 Address").build()));

--- a/src/test/java/seedu/address/model/person/EmailContainsKeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/EmailContainsKeywordPredicateTest.java
@@ -35,7 +35,7 @@ public class EmailContainsKeywordPredicateTest {
     }
 
     @Test
-    public void test_nameContainsKeywords_returnsTrue() {
+    public void test_containsKeywords_returnsTrue() {
         // One keyword
         EmailContainsKeywordPredicate predicate = new EmailContainsKeywordPredicate("email@address.com");
         assertTrue(predicate.test(new PersonBuilder().withEmail("email@address.com").build()));
@@ -46,7 +46,7 @@ public class EmailContainsKeywordPredicateTest {
     }
 
     @Test
-    public void test_nameDoesNotContainKeywords_returnsFalse() {
+    public void test_doesNotContainKeywords_returnsFalse() {
         EmailContainsKeywordPredicate predicate = new EmailContainsKeywordPredicate("address@email.com");
         assertFalse(predicate.test(new PersonBuilder().withEmail("email@address.com").build()));
 

--- a/src/test/java/seedu/address/model/person/PhoneContainsKeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneContainsKeywordPredicateTest.java
@@ -36,7 +36,7 @@ public class PhoneContainsKeywordPredicateTest {
     }
 
     @Test
-    public void test_nameContainsKeywords_returnsTrue() {
+    public void test_containsKeywords_returnsTrue() {
         // One keyword
         PhoneContainsKeywordPredicate predicate = new  PhoneContainsKeywordPredicate("123456");
         assertTrue(predicate.test(new PersonBuilder().withPhone("123456").build()));
@@ -47,7 +47,7 @@ public class PhoneContainsKeywordPredicateTest {
     }
 
     @Test
-    public void test_nameDoesNotContainKeywords_returnsFalse() {
+    public void test_doesNotContainKeywords_returnsFalse() {
 
         PhoneContainsKeywordPredicate predicate = new PhoneContainsKeywordPredicate("654321");
         assertFalse(predicate.test(new PersonBuilder().withPhone("123456").build()));

--- a/src/test/java/seedu/address/model/person/RemarkContainsKeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/RemarkContainsKeywordPredicateTest.java
@@ -1,0 +1,59 @@
+package seedu.address.model.person;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class RemarkContainsKeywordPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstPredicateKeyword = "first";
+        String secondPredicateKeyword = "second";
+
+        RemarkContainsKeywordPredicate firstPredicate = new  RemarkContainsKeywordPredicate(firstPredicateKeyword);
+        RemarkContainsKeywordPredicate secondPredicate = new  RemarkContainsKeywordPredicate(secondPredicateKeyword);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        RemarkContainsKeywordPredicate firstPredicateCopy = new  RemarkContainsKeywordPredicate(firstPredicateKeyword);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_containsKeywords_returnsTrue() {
+        // One keyword
+        RemarkContainsKeywordPredicate predicate = new  RemarkContainsKeywordPredicate("likes");
+        assertTrue(predicate.test(new PersonBuilder().withRemark("hates work but likes food").build()));
+        //ignore case
+        assertTrue(predicate.test(new PersonBuilder().withRemark("Likes to swim").build()));
+    }
+
+    @Test
+    public void test_doesNotContainKeywords_returnsFalse() {
+        RemarkContainsKeywordPredicate predicate = new RemarkContainsKeywordPredicate("hates");
+        assertFalse(predicate.test(new PersonBuilder().withRemark("likes food").build()));
+
+        //super-string
+        predicate = new RemarkContainsKeywordPredicate("hates");
+        assertFalse(predicate.test(new PersonBuilder().withRemark("I hate this").build()));
+
+        // sub-string
+        predicate = new RemarkContainsKeywordPredicate("like");
+        assertFalse(predicate.test(new PersonBuilder().withRemark("hates work but likes food").build()));
+    }
+}

--- a/src/test/java/seedu/address/model/person/TagsContainKeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/TagsContainKeywordPredicateTest.java
@@ -1,0 +1,75 @@
+package seedu.address.model.person;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class TagsContainKeywordPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstPredicateKeyword = "first";
+        String secondPredicateKeyword = "second";
+
+        TagsContainKeywordPredicate firstPredicate = new  TagsContainKeywordPredicate(firstPredicateKeyword);
+        TagsContainKeywordPredicate secondPredicate = new  TagsContainKeywordPredicate(secondPredicateKeyword);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        TagsContainKeywordPredicate firstPredicateCopy = new  TagsContainKeywordPredicate(firstPredicateKeyword);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_containsKeywords_returnsTrue() {
+        // One keyword
+        TagsContainKeywordPredicate predicate = new  TagsContainKeywordPredicate("friends");
+        assertTrue(predicate.test(new PersonBuilder().withTags("friends").build()));
+
+        //multiple tags
+        predicate = new  TagsContainKeywordPredicate("friends");
+        assertTrue(predicate.test(new PersonBuilder().withTags("owesMoney", "friends").build()));
+
+        //multiple similar tags, one match only
+        predicate = new  TagsContainKeywordPredicate("friends");
+        assertTrue(predicate.test(
+                new PersonBuilder().withTags("bestFriends", "friends", "friendsAndPals").build()));
+
+        // sub-string
+        predicate = new TagsContainKeywordPredicate("fri");
+        assertTrue(predicate.test(new PersonBuilder().withTags("friends").build()));
+
+        // Mixed-case
+        predicate = new TagsContainKeywordPredicate("FriEndS");
+        assertTrue(predicate.test(new PersonBuilder().withTags("friends").build()));
+    }
+
+    @Test
+    public void test_doesNotContainKeywords_returnsFalse() {
+
+        TagsContainKeywordPredicate predicate = new TagsContainKeywordPredicate("enemies");
+        assertFalse(predicate.test(new PersonBuilder().withTags("friends").build()));
+
+        predicate = new TagsContainKeywordPredicate("friendsForLife");
+        assertFalse(predicate.test(new PersonBuilder().withTags("friends").build()));
+
+        //multiple similar tags, no match only
+        predicate = new  TagsContainKeywordPredicate("bestFriends");
+        assertFalse(predicate.test(
+                new PersonBuilder().withTags("friendsForLife", "friends", "friendsAndPals").build()));
+    }
+}


### PR DESCRIPTION
This pr creates a new predicate `RemarkContainsKeywordPredicate` for remark finding. It uses `StringUtil#containsWordIgnoreCase` which is case-insensitive but the full word must match.

Resolves #55 