### PR TITLE
Logic: Tab Autocomplete

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MusicCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MusicCommand.java
@@ -44,6 +44,16 @@ public class MusicCommand extends Command {
         this.command = command;
     }
 
+    /**
+     * Returns whether music is currently playing.
+     */
+    public static boolean isPlaying() {
+        if (mediaPlayer == null) {
+            return false;
+        }
+        return mediaPlayer.getStatus() == MediaPlayer.Status.PLAYING;
+    }
+
     @Override
     public CommandResult execute() {
         boolean genreExist = Arrays.asList(genreList).contains(genre);

--- a/src/main/java/seedu/address/logic/parser/HintParser.java
+++ b/src/main/java/seedu/address/logic/parser/HintParser.java
@@ -18,6 +18,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_STRING;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -34,10 +35,12 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.MusicCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.UserPrefs;
 
 /**
  * Class that is responsible for generating hints based on user input
@@ -48,6 +51,72 @@ public class HintParser {
     private static String commandWord;
     private static String arguments;
     private static String userInput;
+
+    private static final Set<String> COMMAND_SET = new HashSet<String>(Arrays.asList(new String[]{
+        "add", "alias", "clear", "delete", "edit", "exit", "find", "help", "history", "list",
+        "music", "redo", "remark", "select", "unalias", "undo"
+    }));
+
+    /**
+     * Parses {@code String input} and returns an appropriate autocompletion
+     */
+    public static String autocomplete(String input) {
+        String[] command;
+
+        try {
+            command = ParserUtil.parseCommandAndArguments(input);
+        } catch (ParseException e) {
+            return "";
+        }
+
+        userInput = input;
+        commandWord = command[0];
+        arguments = command[1];
+
+        switch (commandWord) {
+
+        case AddCommand.COMMAND_WORD:
+            return input + generateAddHint();
+
+        case EditCommand.COMMAND_WORD:
+            return input + generateEditHint();
+
+        case FindCommand.COMMAND_WORD:
+            return input + generateFindHint();
+
+        case MusicCommand.COMMAND_WORD:
+            if (arguments.isEmpty()) {
+                return commandWord + " " + (MusicCommand.isPlaying() ? "pause" : "play");
+            }
+            return commandWord + " " + autocompleteFromList(arguments.trim(), new String[] {"play", "pause", "stop"});
+
+        default:
+            return autocompleteCommand(commandWord);
+        }
+    }
+
+    /**
+     * Parses {@code String command} and returns the closest matching command word.
+     */
+    public static String autocompleteCommand(String command) {
+        Set<String> commands = new HashSet<>();
+        commands.addAll(COMMAND_SET);
+        commands.addAll(UserPrefs.getInstance().getAliases().getAllAliases());
+        String[] list = commands.toArray(new String[commands.size()]);
+        return autocompleteFromList(command, list);
+    }
+
+    /**
+     * Parses {@code String input} and returns the closest matching string in {@code String[] strings}.
+     */
+    public static String autocompleteFromList(String input, String[] strings) {
+        for (String string : strings) {
+            if (string.startsWith(input)) {
+                return string;
+            }
+        }
+        return input;
+    }
 
     /**
      * Parses {@code String input} and returns an appropriate hint

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -19,6 +19,7 @@ import seedu.address.logic.ListElementPointer;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.HintParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -94,6 +95,10 @@ public class CommandBox extends UiPart<Region> {
             keyEvent.consume();
             navigateToNextInput();
             break;
+        case TAB:
+            keyEvent.consume();
+            autocomplete();
+            break;
         default:
             // let JavaFx handle the keypress
         }
@@ -165,6 +170,16 @@ public class CommandBox extends UiPart<Region> {
         // add an empty string to represent the most-recent end of historySnapshot, to be shown to
         // the user if she tries to navigate past the most-recent end of the historySnapshot.
         historySnapshot.add("");
+    }
+
+    /**
+     * Automatically completes user's input and replaces it in the command box.
+     */
+    private void autocomplete() {
+        String input = commandTextField.getText();
+        String autocompletion = HintParser.autocomplete(input);
+        commandTextField.textProperty().set(autocompletion);
+        commandTextField.positionCaret(autocompletion.length());
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/HintParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/HintParserTest.java
@@ -1,12 +1,59 @@
 package seedu.address.logic.parser;
 
 import static org.junit.Assert.assertEquals;
+import static seedu.address.logic.parser.HintParser.autocomplete;
 import static seedu.address.logic.parser.HintParser.generateHint;
 
 import org.junit.Test;
 
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.MusicCommand;
+
 public class HintParserTest {
 
+    @Test
+    public void autocomplete_emptyInput_returnsEmpty() {
+        assertEquals("", autocomplete(""));
+    }
+
+    @Test
+    public void autocomplete_invalidCommand_returnsItself() {
+        assertEquals(
+                "should-not-complete-to-any-commands",
+                autocomplete("should-not-complete-to-any-commands"));
+    }
+
+    @Test
+    public void autocomplete_incompleteCommand_returnsFullCommand() {
+        assertEquals(
+                AddCommand.COMMAND_WORD,
+                autocomplete(AddCommand.COMMAND_WORD.substring(0, AddCommand.COMMAND_WORD.length() - 1)));
+        assertEquals(
+                ListCommand.COMMAND_WORD,
+                autocomplete(ListCommand.COMMAND_WORD.substring(0, ListCommand.COMMAND_WORD.length() - 1)));
+    }
+
+    @Test
+    public void autocomplete_validCommands_returnsParameters() {
+        assertEquals(
+                AddCommand.COMMAND_WORD + " n/NAME",
+                autocomplete(AddCommand.COMMAND_WORD));
+        assertEquals(
+                EditCommand.COMMAND_WORD + " index",
+                autocomplete(EditCommand.COMMAND_WORD));
+        assertEquals(
+                FindCommand.COMMAND_WORD + " n/NAME",
+                autocomplete(FindCommand.COMMAND_WORD));
+        assertEquals(
+                MusicCommand.COMMAND_WORD + " play",
+                autocomplete(MusicCommand.COMMAND_WORD));
+        assertEquals(
+                MusicCommand.COMMAND_WORD + " pause",
+                autocomplete(MusicCommand.COMMAND_WORD + " paus"));
+    }
 
     @Test
     public void generate_add_hint() {

--- a/src/test/java/seedu/address/ui/CommandBoxTest.java
+++ b/src/test/java/seedu/address/ui/CommandBoxTest.java
@@ -11,7 +11,9 @@ import guitests.guihandles.CommandBoxHandle;
 import javafx.scene.input.KeyCode;
 import seedu.address.logic.Logic;
 import seedu.address.logic.LogicManager;
+import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.parser.HintParser;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 
@@ -64,6 +66,16 @@ public class CommandBoxTest extends GuiUnitTest {
         assertEquals(errorStyleOfCommandBox, commandBoxHandle.getStyleClass());
         guiRobot.push(KeyCode.ESCAPE);
         assertEquals(errorStyleOfCommandBox, commandBoxHandle.getStyleClass());
+    }
+
+    @Test
+    public void commandBox_autocomplete() {
+        guiRobot.push(KeyCode.TAB);
+        assertEquals(HintParser.autocomplete(""), commandBoxHandle.getInput());
+
+        commandBoxHandle.type(AddCommand.COMMAND_WORD);
+        guiRobot.push(KeyCode.TAB);
+        assertEquals(HintParser.autocomplete(AddCommand.COMMAND_WORD), commandBoxHandle.getInput());
     }
 
     @Test


### PR DESCRIPTION
This PR introduces a tab completion feature. Users can press `Tab` to automatically complete their inputs into:
- commands and aliases
- context-sensitive command parameters

Resolves #53