### PR TITLE
Feature: Tab completion

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -132,7 +132,7 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]...`
 
 image::UG_header_alias.png[width="400"]
 {sp}+
-Alias: `a`
+Alias: `new`, `create`
 
 [TIP]
 A person can have any number of tags (including 0)
@@ -169,7 +169,7 @@ Format: `list` +
 
 image::UG_header_alias.png[width="400"]
 {sp}+
-Alias: `l`
+Alias: `ls`, `show`
 
 image::UG_header_stepbystep.png[width="400"]
 {sp}+
@@ -198,7 +198,7 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]...` +
 
 image::UG_header_alias.png[width="400"]
 {sp}+
-Alias: `e`
+Alias: `change`
 
 image::header_note.png[width="400"]
 
@@ -243,7 +243,7 @@ to search for people based on their details, which include: +
 
 Find people whose names contain any of the given keywords. +
 Format: `find [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]...` +
-Alias: `f`
+Alias: `search`, `filter`
 
 IMPORTANT: Only people matching all the keywords will be returned (i.e. `AND` search).
 e.g. `n/Hans n/Bo` will not return `Hans Gruber` or `Bo Yang` but will return `Hans Holbo`.
@@ -289,7 +289,7 @@ Format: `delete INDEX` +
 
 image::UG_header_alias.png[width="400"]
 
-Alias: `d`
+Alias: `remove`
 
 image::header_note.png[width="400"]
 
@@ -345,7 +345,7 @@ Format: `select INDEX` +
 
 image::UG_header_alias.png[width="400"]
 
-Alias: `s`
+Alias: `choose`, `pick`
 
 image::header_note.png[width="400"]
 * Selects the person and loads the Google search page the person at the specified `INDEX`.
@@ -422,8 +422,7 @@ image::divider.png[width="900"]
 === Undoing previous command : `undo`
 
 Restores the address book to the state before the previous _undoable_ command was executed. +
-Format: `undo` +
-Alias: `u`
+Format: `undo`
 
 [NOTE]
 ====
@@ -449,8 +448,7 @@ The `undo` command fails as there are no undoable commands executed previously.
 === Redoing the previously undone command : `redo`
 
 Reverses the most recent `undo` command. +
-Format: `redo` +
-Alias: `r`
+Format: `redo`
 
 Examples:
 
@@ -575,8 +573,8 @@ Format: `alias [ALIAS COMMAND]`
 
 Examples:
 
-* `alias show list` +
-`show` (performs the `list` command) +
+* `alias unfriend delete` +
+`unfriend` (performs the `delete` command) +
 * `alias` +
 Lists all your previously defined aliases.
 
@@ -586,9 +584,10 @@ Deletes a previously defined alias. +
 Format: `unalias ALIAS`
 Examples:
 
-* `unalias show` +
-`show` +
-The `show` command fails as there is no longer such a command.
+* `alias unfriend delete` +
+`unalias unfriend` +
+`unfriend` +
+The `unfriend` command fails as there is no longer such a command.
 
 === Exiting the program : `exit`
 image::UG_commandheader_exit.png[width="500"]
@@ -597,6 +596,9 @@ Exits the program. +
 
 image::UG_header_format.png[width="400"]
 Format: `exit`
+
+image::UG_header_alias.png[width="400"]
+Alias: `quit`
 
 image::UG_header_stepbystep.png[width="400"]
 {sp}+

--- a/src/main/java/seedu/address/logic/parser/HintParser.java
+++ b/src/main/java/seedu/address/logic/parser/HintParser.java
@@ -18,7 +18,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_STRING;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -53,7 +52,7 @@ public class HintParser {
     private static String userInput;
 
     //@@author goweiwen
-    private static final Set<String> COMMAND_SET = new HashSet<>(Arrays.asList(
+    private static final ArrayList<String> COMMAND_LIST = new ArrayList<>(Arrays.asList(
         "add", "alias", "clear", "delete", "edit", "exit", "find", "help", "history", "list",
         "music", "redo", "remark", "select", "unalias", "undo"
     ));
@@ -130,8 +129,9 @@ public class HintParser {
      * matches.
      */
     public static String autocompleteCommand(String command) {
-        Set<String> commands = new HashSet<>();
-        commands.addAll(COMMAND_SET);
+        List<String> commands = new ArrayList<>();
+        // We add from COMMAND_LIST first because we want to autocomplete them first.
+        commands.addAll(COMMAND_LIST);
         commands.addAll(UserPrefs.getInstance().getAliases().getAllAliases());
         String[] list = commands.toArray(new String[commands.size()]);
         return autocompleteFromList(command, list);

--- a/src/main/java/seedu/address/logic/parser/HintParser.java
+++ b/src/main/java/seedu/address/logic/parser/HintParser.java
@@ -52,10 +52,11 @@ public class HintParser {
     private static String arguments;
     private static String userInput;
 
-    private static final Set<String> COMMAND_SET = new HashSet<String>(Arrays.asList(new String[]{
+    //@@author goweiwen
+    private static final Set<String> COMMAND_SET = new HashSet<>(Arrays.asList(
         "add", "alias", "clear", "delete", "edit", "exit", "find", "help", "history", "list",
         "music", "redo", "remark", "select", "unalias", "undo"
-    }));
+    ));
 
     /**
      * Parses {@code String input} and returns an appropriate autocompletion
@@ -73,30 +74,60 @@ public class HintParser {
         commandWord = command[0];
         arguments = command[1];
 
+        String hint;
+
         switch (commandWord) {
 
         case AddCommand.COMMAND_WORD:
-            return input + generateAddHint();
+            hint = generateAddHint().trim();
+            // We only want to autocomplete prefixes (e.g. "n/", "a/", etc)
+            if (hint.startsWith("/")) {
+                return input.trim() + "/";
+            }
+            if (hint.startsWith("/", 1)) {
+                return input.trim() + " " + hint.substring(0, 2);
+            }
+            return input;
 
         case EditCommand.COMMAND_WORD:
-            return input + generateEditHint();
+            if (arguments.length() == 0) {
+                return commandWord + " ";
+            }
+            hint = generateEditHint().trim();
+            if (hint.startsWith("/")) {
+                return input.trim() + "/";
+            }
+            if (hint.startsWith("/", 1)) {
+                return input.trim() + " " + hint.substring(0, 2);
+            }
+            return input;
 
         case FindCommand.COMMAND_WORD:
-            return input + generateFindHint();
+            hint = generateFindHint().trim();
+            if (hint.startsWith("/")) {
+                return input.trim() + "/";
+            }
+            if (hint.startsWith("/", 1)) {
+                return input.trim() + " " + hint.substring(0, 2);
+            }
+            return input;
 
         case MusicCommand.COMMAND_WORD:
             if (arguments.isEmpty()) {
                 return commandWord + " " + (MusicCommand.isPlaying() ? "pause" : "play");
             }
-            return commandWord + " " + autocompleteFromList(arguments.trim(), new String[] {"play", "pause", "stop"});
+            hint = autocompleteFromList(arguments.trim(), new String[] {"play", "pause", "stop"});
+            return commandWord + (hint != null ? " " + hint : arguments);
 
         default:
-            return autocompleteCommand(commandWord);
+            hint = autocompleteCommand(commandWord);
+            return hint != null ? hint + " " : input;
         }
     }
 
     /**
-     * Parses {@code String command} and returns the closest matching command word.
+     * Parses {@code String command} and returns the closest matching command word, or null if nothing
+     * matches.
      */
     public static String autocompleteCommand(String command) {
         Set<String> commands = new HashSet<>();
@@ -107,7 +138,8 @@ public class HintParser {
     }
 
     /**
-     * Parses {@code String input} and returns the closest matching string in {@code String[] strings}.
+     * Parses {@code String input} and returns the closest matching string in {@code String[] strings},
+     * or null if nothing matches.
      */
     public static String autocompleteFromList(String input, String[] strings) {
         for (String string : strings) {
@@ -115,9 +147,10 @@ public class HintParser {
                 return string;
             }
         }
-        return input;
+        return null;
     }
 
+    //@@author nicholaschuayunzhi
     /**
      * Parses {@code String input} and returns an appropriate hint
      */

--- a/src/main/java/seedu/address/model/Aliases.java
+++ b/src/main/java/seedu/address/model/Aliases.java
@@ -8,12 +8,12 @@ import java.util.Set;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.RedoCommand;
+import seedu.address.logic.commands.MusicCommand;
 import seedu.address.logic.commands.SelectCommand;
-import seedu.address.logic.commands.UndoCommand;
 
 /**
  * Contains a mapping of aliases to their commands, which is referred to when parsing commands.
@@ -27,15 +27,19 @@ public class Aliases {
      * We initialise the map with aliases for frequently used commands. Users can add other aliases themselves.
      */
     public Aliases() {
-        map.put("a", AddCommand.COMMAND_WORD);
-        map.put("d", DeleteCommand.COMMAND_WORD);
-        map.put("e", EditCommand.COMMAND_WORD);
-        map.put("f", FindCommand.COMMAND_WORD);
-        map.put("h", HelpCommand.COMMAND_WORD);
-        map.put("l", ListCommand.COMMAND_WORD);
-        map.put("r", RedoCommand.COMMAND_WORD);
-        map.put("s", SelectCommand.COMMAND_WORD);
-        map.put("u", UndoCommand.COMMAND_WORD);
+        map.put("new", AddCommand.COMMAND_WORD);
+        map.put("create", AddCommand.COMMAND_WORD);
+        map.put("remove", DeleteCommand.COMMAND_WORD);
+        map.put("change", EditCommand.COMMAND_WORD);
+        map.put("quit", ExitCommand.COMMAND_WORD);
+        map.put("search", FindCommand.COMMAND_WORD);
+        map.put("filter", FindCommand.COMMAND_WORD);
+        map.put("man", HelpCommand.COMMAND_WORD);
+        map.put("ls", ListCommand.COMMAND_WORD);
+        map.put("show", ListCommand.COMMAND_WORD);
+        map.put("song", MusicCommand.COMMAND_WORD);
+        map.put("choose", SelectCommand.COMMAND_WORD);
+        map.put("pick", SelectCommand.COMMAND_WORD);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/HintParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/HintParserTest.java
@@ -27,26 +27,53 @@ public class HintParserTest {
     }
 
     @Test
-    public void autocomplete_incompleteCommand_returnsFullCommand() {
+    public void autocomplete_incompleteCommand_returnsFullCommandAndTrailingSpace() {
         assertEquals(
-                AddCommand.COMMAND_WORD,
+                AddCommand.COMMAND_WORD + " ",
                 autocomplete(AddCommand.COMMAND_WORD.substring(0, AddCommand.COMMAND_WORD.length() - 1)));
         assertEquals(
-                ListCommand.COMMAND_WORD,
+                ListCommand.COMMAND_WORD + " ",
                 autocomplete(ListCommand.COMMAND_WORD.substring(0, ListCommand.COMMAND_WORD.length() - 1)));
     }
 
     @Test
     public void autocomplete_validCommands_returnsParameters() {
         assertEquals(
-                AddCommand.COMMAND_WORD + " n/NAME",
+                AddCommand.COMMAND_WORD + " n/",
                 autocomplete(AddCommand.COMMAND_WORD));
         assertEquals(
-                EditCommand.COMMAND_WORD + " index",
+                AddCommand.COMMAND_WORD + " n/",
+                autocomplete(AddCommand.COMMAND_WORD + " "));
+        assertEquals(
+                AddCommand.COMMAND_WORD + " n/",
+                autocomplete(AddCommand.COMMAND_WORD + " n"));
+        assertEquals(
+                AddCommand.COMMAND_WORD + " n/",
+                autocomplete(AddCommand.COMMAND_WORD + " n/"));
+
+        assertEquals(
+                EditCommand.COMMAND_WORD + " ",
                 autocomplete(EditCommand.COMMAND_WORD));
         assertEquals(
-                FindCommand.COMMAND_WORD + " n/NAME",
+                EditCommand.COMMAND_WORD + " 1 n/",
+                autocomplete(EditCommand.COMMAND_WORD + " 1"));
+        assertEquals(
+                EditCommand.COMMAND_WORD + " 1 n/",
+                autocomplete(EditCommand.COMMAND_WORD + " 1 n"));
+        assertEquals(
+                EditCommand.COMMAND_WORD + " 1 n/",
+                autocomplete(EditCommand.COMMAND_WORD + " 1 n/"));
+
+        assertEquals(
+                FindCommand.COMMAND_WORD + " n/",
                 autocomplete(FindCommand.COMMAND_WORD));
+        assertEquals(
+                FindCommand.COMMAND_WORD + " n/",
+                autocomplete(FindCommand.COMMAND_WORD + " n"));
+        assertEquals(
+                FindCommand.COMMAND_WORD + " n/",
+                autocomplete(FindCommand.COMMAND_WORD + " n/"));
+
         assertEquals(
                 MusicCommand.COMMAND_WORD + " play",
                 autocomplete(MusicCommand.COMMAND_WORD));

--- a/src/test/java/seedu/address/model/AliasesTest.java
+++ b/src/test/java/seedu/address/model/AliasesTest.java
@@ -18,8 +18,8 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ListCommand;
 
 public class AliasesTest {
-    private static final String LIST_COMMAND_ALIAS = "show";
-    private static final String ADD_COMMAND_ALIAS = "create";
+    private static final String LIST_COMMAND_ALIAS = "everyone";
+    private static final String ADD_COMMAND_ALIAS = "someone";
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();


### PR DESCRIPTION
This PR updates tab completion to automatically fill up only until prefixes for `add`, `edit`, and `find` commands. Other commands will autocomplete to end with a trailing space, to help users quickly enter parameters.

Because of the tab completion feature, aliasing commands to short forms no longer make sense. The initial list of aliases is now changed to synonyms of the original commands. e.g. `quit -> exit`

Resolves #66 