### PR TITLE
Logic: Updated & Renamed Email to Share Command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -16,6 +16,7 @@ public class CliSyntax {
     public static final String PREFIX_ADDRESS_STRING = "a/";
     public static final String PREFIX_TAG_STRING = "t/";
     public static final String PREFIX_REMARK_STRING = "r/";
+    public static final String PREFIX_SHARE_STRING = "s/";
     public static final String PREFIX_AVATAR_STRING = "i/";
 
     /* Prefix definitions */
@@ -26,6 +27,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix(PREFIX_ADDRESS_STRING);
     public static final Prefix PREFIX_TAG = new Prefix(PREFIX_TAG_STRING);
     public static final Prefix PREFIX_REMARK = new Prefix(PREFIX_REMARK_STRING);
+    public static final Prefix PREFIX_SHARE = new Prefix(PREFIX_SHARE_STRING);
     public static final Prefix PREFIX_AVATAR = new Prefix(PREFIX_AVATAR_STRING);
 
     public static final List<Prefix> LIST_OF_PREFIXES =

--- a/src/main/java/seedu/address/logic/parser/EmailCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EmailCommandParser.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SHARE;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
@@ -18,19 +20,16 @@ public class EmailCommandParser {
      * @throws ParseException if the user input does not conform the expected format
      */
     public EmailCommand parse(String arguments) throws ParseException {
-        String[] args = arguments.trim().split("\\s+");
-        if (args.length == 2) {
-            String email = args[1];
-            try {
-                Index index = ParserUtil.parseIndex(args[0]);
-                return new EmailCommand(index, email);
-            } catch (IllegalValueException ive) {
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, EmailCommand.MESSAGE_USAGE));
-            }
-        } else {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, EmailCommand.MESSAGE_USAGE));
+        requireNonNull(arguments);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(arguments, PREFIX_SHARE);
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (IllegalValueException ive) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EmailCommand.MESSAGE_USAGE));
         }
+        String share = argMultimap.getValue(PREFIX_SHARE).orElse("");
+        String[] shareEmailArray = share.trim().split("\\s+");
+        return new EmailCommand(index, shareEmailArray);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EmailCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EmailCommandTest.java
@@ -24,6 +24,7 @@ import seedu.address.model.UserPrefs;
 public class EmailCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private String[] shareEmailArray = {"unifycs2103@gmail.com"};
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() throws Exception {
@@ -35,14 +36,15 @@ public class EmailCommandTest {
 
     @Test
     public void equals() {
-        EmailCommand emailFirstCommand = new EmailCommand(INDEX_FIRST_PERSON, "unifycs2103@gmail.com");
-        EmailCommand emailSecondCommand = new EmailCommand(INDEX_SECOND_PERSON, "unifycs2103@gmail.com");
+
+        EmailCommand emailFirstCommand = new EmailCommand(INDEX_FIRST_PERSON, shareEmailArray);
+        EmailCommand emailSecondCommand = new EmailCommand(INDEX_SECOND_PERSON, shareEmailArray);
 
         // same object -> returns true
         assertTrue(emailFirstCommand.equals(emailFirstCommand));
 
         // same values -> returns true
-        EmailCommand emailFirstCommandCopy = new EmailCommand(INDEX_FIRST_PERSON, "unifycs2103@gmail.com");
+        EmailCommand emailFirstCommandCopy = new EmailCommand(INDEX_FIRST_PERSON, shareEmailArray);
         assertTrue(emailFirstCommand.equals(emailFirstCommandCopy));
 
         // different types -> returns false
@@ -60,7 +62,7 @@ public class EmailCommandTest {
      * Returns a {@code EmailCommand} with the parameter {@code index}.
      */
     private EmailCommand prepareCommand(Index index) {
-        EmailCommand emailCommand = new EmailCommand(index, "unifycs2103@gmail.com");
+        EmailCommand emailCommand = new EmailCommand(index, shareEmailArray);
         emailCommand.setData(model, new CommandHistory(), new UndoRedoStack());
         return emailCommand;
     }


### PR DESCRIPTION
Email Command is now renamed to Share Command which allow the use of index (email data from selected index) or email address as a string input to be used as recipient email address.

This feature now able to send to multiple recipient. 

This resolves #105