### PR TITLE
Logic: Fix tab cycle bug

### DIFF
--- a/src/main/java/seedu/address/commons/util/HintUtil.java
+++ b/src/main/java/seedu/address/commons/util/HintUtil.java
@@ -73,15 +73,15 @@ public class HintUtil {
     }
 
     /**
-     * returns prefix if the given {@code arguments}
+     * returns prefix if the given {@code userInput}
      * ends with the full prefix that's inside the list of {@code prefixes} provided.
      *
      * If no prefix is present, we return an empty optional.
      */
-    public static Optional<Prefix> findEndPrefix(String arguments, List<Prefix> prefixes) {
+    public static Optional<Prefix> findEndPrefix(String userInput, List<Prefix> prefixes) {
 
         for (Prefix p : prefixes) {
-            if (arguments.endsWith(p.toString())) {
+            if (userInput.endsWith(p.toString())) {
                 return Optional.of(p);
             }
         }

--- a/src/main/java/seedu/address/logic/commands/hints/AddCommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/AddCommandHint.java
@@ -55,7 +55,7 @@ public class AddCommandHint extends ArgumentsHint {
 
         // can we tab through prefixes
         // case: add n/|
-        Optional<Prefix> endPrefix = HintUtil.findEndPrefix(arguments, PREFIXES);
+        Optional<Prefix> endPrefix = HintUtil.findEndPrefix(userInput, PREFIXES);
         if (endPrefix.isPresent()) {
             handlePrefixTabbing(endPrefix.get(), PREFIXES, possiblePrefixesToComplete);
             return;

--- a/src/main/java/seedu/address/logic/commands/hints/EditCommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/EditCommandHint.java
@@ -67,7 +67,7 @@ public class EditCommandHint extends ArgumentsHint {
 
         // can we tab through prefixes
         // case: edit 1 n/|
-        Optional<Prefix> endPrefix = HintUtil.findEndPrefix(arguments, PREFIXES);
+        Optional<Prefix> endPrefix = HintUtil.findEndPrefix(userInput, PREFIXES);
         if (endPrefix.isPresent()) {
             handlePrefixTabbing(endPrefix.get(), PREFIXES, possiblePrefixesToComplete);
             return;

--- a/src/main/java/seedu/address/logic/commands/hints/FindCommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/FindCommandHint.java
@@ -49,7 +49,7 @@ public class FindCommandHint extends ArgumentsHint {
 
         // can we tab through prefixes
         // case: find n/|
-        Optional<Prefix> endPrefix = HintUtil.findEndPrefix(arguments, PREFIXES);
+        Optional<Prefix> endPrefix = HintUtil.findEndPrefix(userInput, PREFIXES);
         if (endPrefix.isPresent()) {
 
             //we can offer duplicates, so offer every other prefix


### PR DESCRIPTION
Resolves the bug where
`n/ |` -> <kbd>Tab</kbd> -> `np|`