### PR TITLE
Logic: Fix Hints bug and Refactor Hints

### DIFF
--- a/src/main/java/seedu/address/logic/Autocomplete.java
+++ b/src/main/java/seedu/address/logic/Autocomplete.java
@@ -35,9 +35,9 @@ public class Autocomplete {
         String commandWord = command[0];
         String arguments = command[1];
 
-        Hint hint = HintParser.generateParsedHint(input, arguments, commandWord);
-        String autoCompletedHint = hint.autocomplete();
-        return autoCompletedHint != null ? autoCompletedHint : input;
+        Hint hint = HintParser.generateHint(input, arguments, commandWord);
+        hint.requireFieldsNonNull();
+        return hint.autocomplete();
     }
 
     /**

--- a/src/main/java/seedu/address/logic/Autocomplete.java
+++ b/src/main/java/seedu/address/logic/Autocomplete.java
@@ -54,7 +54,7 @@ public class Autocomplete {
     }
 
     /**
-     * Parses {@code String input} and returnsthe closest matching string in {@code String[] strings},
+     * Parses {@code String input} and returns the closest matching string in {@code String[] strings},
      * or null if nothing matches.
      */
     public static String autocompleteFromList(String input, String[] strings) {

--- a/src/main/java/seedu/address/logic/commands/hints/AddCommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/AddCommandHint.java
@@ -39,10 +39,15 @@ public class AddCommandHint extends ArgumentsHint {
     public AddCommandHint(String userInput, String arguments) {
         this.userInput = userInput;
         this.arguments = arguments;
+        parse();
     }
 
-    @Override
-    public void parse() {
+    /**
+     * parses {@code userInput} and {@code arguments}
+     * sets appropriate {@code argumentHint}, {@code description}, {@code onTab}
+     * for Add Command
+     */
+    private void parse() {
         possiblePrefixesToComplete = HintUtil.getUncompletedPrefixes(arguments, PREFIXES);
 
         Optional<String> prefixCompletionOptional =

--- a/src/main/java/seedu/address/logic/commands/hints/AliasCommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/AliasCommandHint.java
@@ -11,6 +11,7 @@ public class AliasCommandHint extends Hint {
         this.userInput = userInput;
         this.arguments = arguments;
         argumentHint = "";
+        parse();
     }
 
     @Override
@@ -19,8 +20,12 @@ public class AliasCommandHint extends Hint {
         return userInput + whitespace;
     }
 
-    @Override
-    public void parse() {
+    /**
+     * parses {@code userInput} and {@code arguments}
+     * sets appropriate {@code argumentHint}, {@code description}
+     * for an Alias Command
+     */
+    private void parse() {
 
         if (arguments.length() == 0 && !userInput.endsWith(" ")) {
             description = " shows all aliases";

--- a/src/main/java/seedu/address/logic/commands/hints/ArgumentsHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/ArgumentsHint.java
@@ -29,7 +29,6 @@ public abstract class ArgumentsHint extends Hint {
         Prefix p = HintUtil.findPrefixOfCompletionHint(arguments, possiblePrefixesToComplete);
         description = getDescription(p);
         onTab = userInput + argumentHint;
-        assertRequiredIsNonNull();
         LOGGER.info("ArgumentsHint - Handled Prefix Completion");
     }
 
@@ -46,7 +45,6 @@ public abstract class ArgumentsHint extends Hint {
         description = getDescription(currentPrefix);
         Prefix nextPrefix = generateNextPrefix(currentPrefix, prefixList, possiblePrefixesToComplete);
         onTab = userInput.substring(0, userInput.length() - 2) + nextPrefix.toString();
-        assertRequiredIsNonNull();
         LOGGER.info("ArgumentsHint - Handled Prefix Tabbing");
     }
 
@@ -78,7 +76,6 @@ public abstract class ArgumentsHint extends Hint {
         argumentHint = whitespace + offeredPrefix.toString();
         description = getDescription(offeredPrefix);
         onTab = userInput + argumentHint;
-        assertRequiredIsNonNull();
         LOGGER.info("ArgumentsHint - Handled Prefix Offer");
     }
 
@@ -92,7 +89,6 @@ public abstract class ArgumentsHint extends Hint {
         argumentHint = whitespace + "1";
         description = " index";
         onTab = userInput + argumentHint;
-        assertRequiredIsNonNull();
         LOGGER.info("ArgumentsHint - Handled Index Offer");
     }
 
@@ -108,7 +104,6 @@ public abstract class ArgumentsHint extends Hint {
 
         int newIndex = currentIndex + 1;
         onTab = userInput.substring(0, userInput.length() - length) + newIndex;
-        assertRequiredIsNonNull();
         LOGGER.info("ArgumentsHint - Handled Index Tabbing");
     }
 

--- a/src/main/java/seedu/address/logic/commands/hints/ClearCommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/ClearCommandHint.java
@@ -11,6 +11,7 @@ public class ClearCommandHint extends NoArgumentsHint {
     public ClearCommandHint(String userInput) {
         this.userInput = userInput;
         this.description = CLEAR_COMMAND_DESC;
+        parse();
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/hints/CommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/CommandHint.java
@@ -36,7 +36,7 @@ public class CommandHint extends Hint {
 
     @Override
     public String autocomplete() {
-        return userInput + argumentHint;
+        return userInput.trim() + argumentHint;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/hints/CommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/CommandHint.java
@@ -23,7 +23,7 @@ import seedu.address.model.Aliases;
 import seedu.address.model.UserPrefs;
 
 /**
- * Generates hint and autocompletion for command words
+ * Generates hint and autocompletion for any uncompleted command word
  */
 public class CommandHint extends Hint {
 
@@ -32,6 +32,7 @@ public class CommandHint extends Hint {
     public CommandHint(String userInput, String commandWord) {
         this.userInput = userInput;
         this.commandWord = commandWord;
+        parse();
     }
 
     @Override
@@ -39,8 +40,12 @@ public class CommandHint extends Hint {
         return userInput.trim() + argumentHint;
     }
 
-    @Override
-    public void parse() {
+    /**
+     * parses {@code userInput} and {@code commandWord}
+     * sets appropriate {@code argumentHint}, {@code description}
+     * for any uncompleted command word
+     */
+    private void parse() {
         String autocompleted = Autocomplete.autocompleteCommand(commandWord);
 
         if (autocompleted == null) {

--- a/src/main/java/seedu/address/logic/commands/hints/DeleteCommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/DeleteCommandHint.java
@@ -12,10 +12,16 @@ public class DeleteCommandHint extends ArgumentsHint {
     public DeleteCommandHint(String userInput, String arguments) {
         this.userInput = userInput;
         this.arguments = arguments;
+        parse();
+
     }
 
-    @Override
-    public void parse() {
+    /**
+     * parses {@code userInput} and {@code arguments}
+     * sets appropriate {@code argumentHint}, {@code description}, {@code onTab}
+     * for Delete Command
+     */
+    private void parse() {
         //case : delete *|
         if (!HintUtil.hasIndex(arguments)) {
             handleOfferIndex(userInput);
@@ -31,6 +37,5 @@ public class DeleteCommandHint extends ArgumentsHint {
         description = "";
         argumentHint = "";
         onTab = userInput;
-        assertRequiredIsNonNull();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/hints/EditCommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/EditCommandHint.java
@@ -35,10 +35,15 @@ public class EditCommandHint extends ArgumentsHint {
     public EditCommandHint(String userInput, String arguments) {
         this.userInput = userInput;
         this.arguments = arguments;
+        parse();
     }
 
-    @Override
-    public void parse() {
+    /**
+     * parses {@code userInput} and {@code arguments}
+     * sets appropriate {@code argumentHint}, {@code description}, {@code onTab}
+     * for Edit Command
+     */
+    private void parse() {
         //case : edit *|
         if (!HintUtil.hasPreambleIndex(arguments)) {
             handleOfferIndex(userInput);

--- a/src/main/java/seedu/address/logic/commands/hints/ExitCommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/ExitCommandHint.java
@@ -11,5 +11,6 @@ public class ExitCommandHint extends NoArgumentsHint {
     public ExitCommandHint(String userInput) {
         this.userInput = userInput;
         this.description = EXIT_COMMAND_DESC;
+        parse();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/hints/FindCommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/FindCommandHint.java
@@ -34,10 +34,15 @@ public class FindCommandHint extends ArgumentsHint {
     public FindCommandHint(String userInput, String arguments) {
         this.userInput = userInput;
         this.arguments = arguments;
+        parse();
     }
 
-    @Override
-    public void parse() {
+    /**
+     * parses {@code userInput} and {@code arguments}
+     * sets appropriate {@code argumentHint}, {@code description}, {@code onTab}
+     * for Find Command
+     */
+    private void parse() {
         Optional<String> prefixCompletionOptional = HintUtil.findPrefixCompletionHint(arguments, PREFIXES);
 
         // are we completing a hint?
@@ -68,7 +73,6 @@ public class FindCommandHint extends ArgumentsHint {
 
         //TODO: never exhaust the prefix offers
         handleOfferHint(PREFIXES);
-        assertRequiredIsNonNull();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/hints/HelpCommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/HelpCommandHint.java
@@ -11,5 +11,6 @@ public class HelpCommandHint extends NoArgumentsHint {
     public HelpCommandHint(String userInput) {
         this.userInput = userInput;
         this.description = HELP_COMMAND_DESC;
+        parse();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/hints/Hint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/Hint.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands.hints;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.logging.Logger;
 
 import seedu.address.commons.core.LogsCenter;
@@ -16,30 +18,35 @@ public abstract class Hint {
     protected String userInput;
     protected String arguments;
 
-    public abstract void parse();
+    /**
+     * returns the new user input when user presses tab
+     */
     public abstract String autocomplete();
+
+    /**
+     * returns the argument hint of current user input
+     */
+    public String getArgumentHint() {
+        return argumentHint;
+    }
+
+    /**
+     * returns the description of current user input
+     */
+    public String getDescription() {
+        return description;
+    }
 
     /**
      * asserts that require info is non null
      * should be called after parse()
      */
-    protected final void assertRequiredIsNonNull() {
-
-        if ((argumentHint == null)
-                || (description == null)
-                || (userInput == null)
-                || (autocomplete() == null)) {
-            assert false;
-        }
-
-
+    public final void requireFieldsNonNull() {
+        requireNonNull(argumentHint);
+        requireNonNull(description);
+        requireNonNull(userInput);
+        requireNonNull(autocomplete());
     }
 
-    public String getArgumentHint() {
-        return argumentHint;
-    }
 
-    public String getDescription() {
-        return description;
-    }
 }

--- a/src/main/java/seedu/address/logic/commands/hints/HistoryCommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/HistoryCommandHint.java
@@ -11,5 +11,6 @@ public class HistoryCommandHint extends NoArgumentsHint {
     public HistoryCommandHint(String userInput) {
         this.userInput = userInput;
         this.description = HISTORY_COMMAND_DESC;
+        parse();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/hints/ListCommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/ListCommandHint.java
@@ -11,5 +11,6 @@ public class ListCommandHint extends NoArgumentsHint {
     public ListCommandHint(String userInput) {
         this.userInput = userInput;
         this.description = LIST_COMMAND_DESC;
+        parse();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/hints/MusicCommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/MusicCommandHint.java
@@ -16,11 +16,15 @@ public class MusicCommandHint extends FixedArgumentsHint {
     public MusicCommandHint(String userInput, String arguments) {
         this.userInput = userInput;
         this.arguments = arguments;
+        parse();
     }
 
-
-    @Override
-    public void parse() {
+    /**
+     * parses {@code userInput} and {@code arguments}
+     * sets appropriate {@code argumentHint}, {@code description}, {@code autoCorrectInput}
+     * for Music Command
+     */
+    private void parse() {
 
         String[] args = arguments.trim().split("\\s+");
 

--- a/src/main/java/seedu/address/logic/commands/hints/NoArgumentsHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/NoArgumentsHint.java
@@ -11,8 +11,12 @@ public abstract class NoArgumentsHint extends Hint {
         argumentHint = "";
     }
 
-    @Override
-    public void parse() {
+    /**
+     * parses {@code userInput}
+     * sets appropriate {@code description}
+     * for any No Argument Command
+     */
+    protected void parse() {
         String whitespace = userInput.endsWith(" ") ? "" : " ";
         this.description = whitespace + this.description;
     }

--- a/src/main/java/seedu/address/logic/commands/hints/RadioCommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/RadioCommandHint.java
@@ -16,11 +16,15 @@ public class RadioCommandHint extends FixedArgumentsHint {
     public RadioCommandHint(String userInput, String arguments) {
         this.userInput = userInput;
         this.arguments = arguments;
+        parse();
     }
 
-    @Override
-    public void parse() {
-
+    /**
+     * parses {@code userInput} and {@code arguments}
+     * sets appropriate {@code argumentHint}, {@code description}, {@code autoCorrectInput}
+     * for Radio Command
+     */
+    private void parse() {
         String[] args = arguments.trim().split("\\s+");
 
         String actionArgument = args[0];

--- a/src/main/java/seedu/address/logic/commands/hints/RedoCommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/RedoCommandHint.java
@@ -11,6 +11,7 @@ public class RedoCommandHint extends NoArgumentsHint {
     public RedoCommandHint(String userInput) {
         this.userInput = userInput;
         this.description = REDO_COMMAND_DESC;
+        parse();
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/hints/ShareCommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/ShareCommandHint.java
@@ -24,11 +24,15 @@ public class ShareCommandHint extends ArgumentsHint {
     public ShareCommandHint(String userInput, String arguments) {
         this.userInput = userInput;
         this.arguments = arguments;
+        parse();
     }
 
-    @Override
-    public void parse() {
-
+    /**
+     * parses {@code userInput} and {@code arguments}
+     * sets appropriate {@code argumentHint}, {@code description}, {@code onTab}
+     * for Share Command
+     */
+    private void parse() {
         if (!HintUtil.hasPreambleIndex(arguments)) {
             handleOfferIndex(userInput);
             return;
@@ -76,8 +80,6 @@ public class ShareCommandHint extends ArgumentsHint {
             onTab = userInput + argumentHint;
             description = getDescription(offeredPrefix);
         }
-
-        assertRequiredIsNonNull();
         LOGGER.info("ArgumentsHint - Handled Prefix Offer");
     }
 

--- a/src/main/java/seedu/address/logic/commands/hints/UnaliasCommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/UnaliasCommandHint.java
@@ -11,6 +11,7 @@ public class UnaliasCommandHint extends Hint {
         this.userInput = userInput;
         this.arguments = arguments;
         this.argumentHint = "";
+        parse();
     }
 
     @Override
@@ -19,8 +20,12 @@ public class UnaliasCommandHint extends Hint {
         return userInput + whitespace;
     }
 
-    @Override
-    public void parse() {
+    /**
+     * parses {@code userInput} and {@code arguments}
+     * sets appropriate {@code argumentHint}, {@code description}
+     * for Unalias Command
+     */
+    private void parse() {
         String[] args = arguments.trim().split("\\s+");
 
         if (args[0].isEmpty()) {

--- a/src/main/java/seedu/address/logic/commands/hints/UndoCommandHint.java
+++ b/src/main/java/seedu/address/logic/commands/hints/UndoCommandHint.java
@@ -11,5 +11,6 @@ public class UndoCommandHint extends NoArgumentsHint {
     public UndoCommandHint(String userInput) {
         this.userInput = userInput;
         this.description = UNDO_COMMAND_DESC;
+        parse();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/HintParser.java
+++ b/src/main/java/seedu/address/logic/parser/HintParser.java
@@ -59,11 +59,8 @@ public class HintParser {
         String userInput = input;
         String commandWord = command[0];
         String arguments = command[1];
-        Hint hint = generateParsedHint(userInput, arguments, commandWord);
-        if (hint == null) {
-            return " type help for user guide";
-        }
-
+        Hint hint = generateHint(userInput, arguments, commandWord);
+        hint.requireFieldsNonNull();
         return hint.getArgumentHint() + hint.getDescription();
     }
 
@@ -72,7 +69,7 @@ public class HintParser {
      * userInput and arguments are referenced to decide whether whitespace should be added to
      * the front of the hint
      */
-    private static Hint generateHint(String userInput, String arguments, String commandWord) {
+    public static Hint generateHint(String userInput, String arguments, String commandWord) {
 
         switch (commandWord) {
         case AddCommand.COMMAND_WORD:
@@ -111,16 +108,5 @@ public class HintParser {
         default:
             return new CommandHint(userInput, commandWord);
         }
-    }
-
-    /**
-     * returns a parsedHint if generated hint is non null, else return null
-     */
-    public static Hint generateParsedHint(String userInput, String arguments, String commandWord) {
-        Hint generatedHint = generateHint(userInput, arguments, commandWord);
-        if (generatedHint != null) {
-            generatedHint.parse();
-        }
-        return generatedHint;
     }
 }

--- a/src/test/java/seedu/address/logic/hints/AddCommandHintTest.java
+++ b/src/test/java/seedu/address/logic/hints/AddCommandHintTest.java
@@ -13,42 +13,42 @@ public class AddCommandHintTest {
     public void parseTest() {
         //offer hint
         AddCommandHint addCommandHint = new AddCommandHint("add", "");
-        parseAndAssertHint(addCommandHint, " n/", "name", "add n/");
+        assertHintContent(addCommandHint, " n/", "name", "add n/");
         addCommandHint = new AddCommandHint("add n/ ", " n/ ");
-        parseAndAssertHint(addCommandHint, "p/", "phone", "add n/ p/");
+        assertHintContent(addCommandHint, "p/", "phone", "add n/ p/");
         addCommandHint = new AddCommandHint("add n/nicholas p/321 e/email@e.com a/address",
                 " n/nicholas p/321 e/email@e.com a/address");
-        parseAndAssertHint(addCommandHint, " r/", "remark (optional)",
+        assertHintContent(addCommandHint, " r/", "remark (optional)",
                 "add n/nicholas p/321 e/email@e.com a/address r/");
         //prefix completion
         addCommandHint = new AddCommandHint("add n", " n");
-        parseAndAssertHint(addCommandHint, "/", "name", "add n/");
+        assertHintContent(addCommandHint, "/", "name", "add n/");
         addCommandHint = new AddCommandHint("add p", " p");
-        parseAndAssertHint(addCommandHint, "/", "phone", "add p/");
+        assertHintContent(addCommandHint, "/", "phone", "add p/");
         addCommandHint = new AddCommandHint("add e", " e");
-        parseAndAssertHint(addCommandHint, "/", "email", "add e/");
+        assertHintContent(addCommandHint, "/", "email", "add e/");
 
         //prefix cycle
         addCommandHint = new AddCommandHint("add i/", " i/");
-        parseAndAssertHint(addCommandHint, "", "avatar file path (optional)", "add n/");
+        assertHintContent(addCommandHint, "", "avatar file path (optional)", "add n/");
         addCommandHint = new AddCommandHint("add a/", " a/");
-        parseAndAssertHint(addCommandHint, "", "address", "add r/");
+        assertHintContent(addCommandHint, "", "address", "add r/");
 
         //exhausted all prefix
         addCommandHint = new AddCommandHint("add n/nicholas p/321 e/email@e.com a/address t/tag i/picture.png r/remark",
                 " n/nicholas p/321 e/email@e.com a/address t/tag i/picture.png r/remark");
-        parseAndAssertHint(addCommandHint, " ", "",
+        assertHintContent(addCommandHint, " ", "",
                 "add n/nicholas p/321 e/email@e.com a/address t/tag i/picture.png r/remark ");
     }
 
     /**
      * parses {@code hint} and checks if the the hint generated has the expected fields
      */
-    public static void parseAndAssertHint(Hint hint,
-                                          String expectedArgumentHint,
-                                          String expectedDescription,
-                                          String expectedAutocomplete) {
-        hint.parse();
+    public static void assertHintContent(Hint hint,
+                                         String expectedArgumentHint,
+                                         String expectedDescription,
+                                         String expectedAutocomplete) {
+
         assertEquals(expectedArgumentHint, hint.getArgumentHint());
         assertEquals(expectedDescription, hint.getDescription());
         assertEquals(expectedAutocomplete, hint.autocomplete());

--- a/src/test/java/seedu/address/logic/hints/AliasCommandHintTest.java
+++ b/src/test/java/seedu/address/logic/hints/AliasCommandHintTest.java
@@ -8,31 +8,31 @@ public class AliasCommandHintTest {
     @Test
     public void aliasCommandHint() {
         AliasCommandHint aliasCommandHint = new AliasCommandHint("alias", "");
-        parseAndAssertHint(
+        assertHint(
                 aliasCommandHint,
                 " shows all aliases",
                 "alias ");
 
         aliasCommandHint = new AliasCommandHint("alias ", "");
-        parseAndAssertHint(
+        assertHint(
                 aliasCommandHint,
                 " - set your new command word",
                 "alias ");
 
         aliasCommandHint = new AliasCommandHint("alias s", "s");
-        parseAndAssertHint(
+        assertHint(
                 aliasCommandHint,
                 " - set your new command word",
                 "alias s ");
 
         aliasCommandHint = new AliasCommandHint("alias s ", "s");
-        parseAndAssertHint(
+        assertHint(
                 aliasCommandHint,
                 " - set what s represents",
                 "alias s ");
 
         aliasCommandHint = new AliasCommandHint("alias hehe ", "hehe");
-        parseAndAssertHint(
+        assertHint(
                 aliasCommandHint,
                 " - set what hehe represents",
                 "alias hehe ");
@@ -42,10 +42,10 @@ public class AliasCommandHintTest {
     /**
      * parses {@code aliasCommandHint} and checks if the the hint generated has the expected fields
      */
-    private void parseAndAssertHint(AliasCommandHint aliasCommandHint,
-                                    String expectedDesc,
-                                    String expectedAutocomplete) {
-        AddCommandHintTest.parseAndAssertHint(
+    private void assertHint(AliasCommandHint aliasCommandHint,
+                            String expectedDesc,
+                            String expectedAutocomplete) {
+        AddCommandHintTest.assertHintContent(
                 aliasCommandHint,
                 "",
                 expectedDesc,

--- a/src/test/java/seedu/address/logic/hints/CommandHintTest.java
+++ b/src/test/java/seedu/address/logic/hints/CommandHintTest.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.hints;
 
-import static seedu.address.logic.hints.AddCommandHintTest.parseAndAssertHint;
+import static seedu.address.logic.hints.AddCommandHintTest.assertHintContent;
 
 import org.junit.Test;
 
@@ -11,133 +11,133 @@ public class CommandHintTest {
     @Test
     public void commandHintTest() {
         CommandHint commandHint = new CommandHint("a", "a");
-        parseAndAssertHint(
+        assertHintContent(
                 commandHint,
                 "dd ",
                 "adds a person",
                 "add ");
 
         commandHint = new CommandHint("ad", "ad");
-        parseAndAssertHint(
+        assertHintContent(
                 commandHint,
                 "d ",
                 "adds a person",
                 "add ");
 
         commandHint = new CommandHint(" ad ", "ad");
-        parseAndAssertHint(
+        assertHintContent(
                 commandHint,
                 "d ",
                 "adds a person",
                 "add ");
 
         commandHint = new CommandHint("find", "find");
-        parseAndAssertHint(
+        assertHintContent(
                 commandHint,
                 " ",
                 "finds a person",
                 "find ");
 
         commandHint = new CommandHint("j", "j");
-        parseAndAssertHint(
+        assertHintContent(
                 commandHint,
                 "",
                 " type help for user guide",
                 "j");
 
         commandHint = new CommandHint("edit", "edit");
-        parseAndAssertHint(
+        assertHintContent(
                 commandHint,
                 " ",
                 "edits a person",
                 "edit ");
 
         commandHint = new CommandHint("select", "select");
-        parseAndAssertHint(
+        assertHintContent(
                 commandHint,
                 " ",
                 "selects a person",
                 "select ");
 
         commandHint = new CommandHint("share", "share");
-        parseAndAssertHint(
+        assertHintContent(
                 commandHint,
                 " ",
                 "shares a contact via email",
                 "share ");
 
         commandHint = new CommandHint("clear", "clear");
-        parseAndAssertHint(
+        assertHintContent(
                 commandHint,
                 " ",
                 "clears all contacts",
                 "clear ");
 
         commandHint = new CommandHint("history", "history");
-        parseAndAssertHint(
+        assertHintContent(
                 commandHint,
                 " ",
                 "shows command history",
                 "history ");
 
         commandHint = new CommandHint("exit", "exit");
-        parseAndAssertHint(
+        assertHintContent(
                 commandHint,
                 " ",
                 "exits the application",
                 "exit ");
 
         commandHint = new CommandHint("undo", "undo");
-        parseAndAssertHint(
+        assertHintContent(
                 commandHint,
                 " ",
                 "undo previous command",
                 "undo ");
 
         commandHint = new CommandHint("redo", "redo");
-        parseAndAssertHint(
+        assertHintContent(
                 commandHint,
                 " ",
                 "redo command",
                 "redo ");
 
         commandHint = new CommandHint("help", "help");
-        parseAndAssertHint(
+        assertHintContent(
                 commandHint,
                 " ",
                 "shows user guide",
                 "help ");
 
         commandHint = new CommandHint("music", "music");
-        parseAndAssertHint(
+        assertHintContent(
                 commandHint,
                 " ",
                 "plays music",
                 "music ");
 
         commandHint = new CommandHint("radio", "radio");
-        parseAndAssertHint(
+        assertHintContent(
                 commandHint,
                 " ",
                 "plays the radio",
                 "radio ");
 
         commandHint = new CommandHint("alias", "alias");
-        parseAndAssertHint(
+        assertHintContent(
                 commandHint,
                 " ",
                 "sets or show alias",
                 "alias ");
 
         commandHint = new CommandHint("unalias", "unalias");
-        parseAndAssertHint(
+        assertHintContent(
                 commandHint,
                 " ",
                 "removes alias",
                 "unalias ");
 
         commandHint = new CommandHint("unknown", "unknown");
-        parseAndAssertHint(
+        assertHintContent(
                 commandHint,
                 "",
                 " type help for user guide",

--- a/src/test/java/seedu/address/logic/hints/CommandHintTest.java
+++ b/src/test/java/seedu/address/logic/hints/CommandHintTest.java
@@ -24,6 +24,13 @@ public class CommandHintTest {
                 "adds a person",
                 "add ");
 
+        commandHint = new CommandHint(" ad ", "ad");
+        parseAndAssertHint(
+                commandHint,
+                "d ",
+                "adds a person",
+                "add ");
+
         commandHint = new CommandHint("find", "find");
         parseAndAssertHint(
                 commandHint,

--- a/src/test/java/seedu/address/logic/hints/DeleteCommandHintTest.java
+++ b/src/test/java/seedu/address/logic/hints/DeleteCommandHintTest.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.hints;
 
-import static seedu.address.logic.hints.AddCommandHintTest.parseAndAssertHint;
+import static seedu.address.logic.hints.AddCommandHintTest.assertHintContent;
 
 import org.junit.Test;
 
@@ -12,21 +12,21 @@ public class DeleteCommandHintTest {
     public void parseTest() {
         //offer index
         DeleteCommandHint deleteCommandHint = new DeleteCommandHint("delete", "");
-        parseAndAssertHint(deleteCommandHint, " 1", " index", "delete 1");
+        assertHintContent(deleteCommandHint, " 1", " index", "delete 1");
 
         deleteCommandHint = new DeleteCommandHint("delete ", " ");
-        parseAndAssertHint(deleteCommandHint, "1", " index", "delete 1");
+        assertHintContent(deleteCommandHint, "1", " index", "delete 1");
         //index cycle
         deleteCommandHint = new DeleteCommandHint("delete 5", " 5");
-        parseAndAssertHint(deleteCommandHint, "", " index", "delete 6");
+        assertHintContent(deleteCommandHint, "", " index", "delete 6");
 
         //delete is used for select. TODO: give select command its own hint
 
         deleteCommandHint = new DeleteCommandHint("select", "");
-        parseAndAssertHint(deleteCommandHint, " 1", " index", "select 1");
+        assertHintContent(deleteCommandHint, " 1", " index", "select 1");
 
         deleteCommandHint = new DeleteCommandHint("select ", " ");
-        parseAndAssertHint(deleteCommandHint, "1", " index", "select 1");
+        assertHintContent(deleteCommandHint, "1", " index", "select 1");
 
     }
 }

--- a/src/test/java/seedu/address/logic/hints/EditCommandHintTest.java
+++ b/src/test/java/seedu/address/logic/hints/EditCommandHintTest.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.hints;
 
-import static seedu.address.logic.hints.AddCommandHintTest.parseAndAssertHint;
+import static seedu.address.logic.hints.AddCommandHintTest.assertHintContent;
 
 import org.junit.Test;
 
@@ -12,41 +12,41 @@ public class EditCommandHintTest {
     public void parseTest() {
         //offer index
         EditCommandHint editCommandHint = new EditCommandHint("edit", "");
-        parseAndAssertHint(editCommandHint, " 1", " index", "edit 1");
+        assertHintContent(editCommandHint, " 1", " index", "edit 1");
 
         //offer hint
         editCommandHint = new EditCommandHint("edit 5 ", " 5 ");
-        parseAndAssertHint(editCommandHint, "n/", "name", "edit 5 n/");
+        assertHintContent(editCommandHint, "n/", "name", "edit 5 n/");
         editCommandHint = new EditCommandHint("edit 1 n/nicholas p/321 e/email@e.com a/address",
                 " 1 n/nicholas p/321 e/email@e.com a/address");
-        parseAndAssertHint(editCommandHint, " r/", "remark",
+        assertHintContent(editCommandHint, " r/", "remark",
                 "edit 1 n/nicholas p/321 e/email@e.com a/address r/");
 
         //index cycle
         editCommandHint = new EditCommandHint("edit 5", " 5");
-        parseAndAssertHint(editCommandHint, "", " index", "edit 6");
+        assertHintContent(editCommandHint, "", " index", "edit 6");
 
 
         //prefix completion
         editCommandHint = new EditCommandHint("edit 5 n", " 5 n");
-        parseAndAssertHint(editCommandHint, "/", "name", "edit 5 n/");
+        assertHintContent(editCommandHint, "/", "name", "edit 5 n/");
         editCommandHint = new EditCommandHint("edit 3 n/ ", " 3 n/ ");
-        parseAndAssertHint(editCommandHint, "p/", "phone", "edit 3 n/ p/");
+        assertHintContent(editCommandHint, "p/", "phone", "edit 3 n/ p/");
         editCommandHint = new EditCommandHint("edit 2 p", " 2 p");
-        parseAndAssertHint(editCommandHint, "/", "phone", "edit 2 p/");
+        assertHintContent(editCommandHint, "/", "phone", "edit 2 p/");
         editCommandHint = new EditCommandHint("edit 4 e", " 4 e");
-        parseAndAssertHint(editCommandHint, "/", "email", "edit 4 e/");
+        assertHintContent(editCommandHint, "/", "email", "edit 4 e/");
 
         //prefix cycle
         editCommandHint = new EditCommandHint("edit 1 t/", " 1 t/");
-        parseAndAssertHint(editCommandHint, "", "tag", "edit 1 n/");
+        assertHintContent(editCommandHint, "", "tag", "edit 1 n/");
         editCommandHint = new EditCommandHint("edit 3 r/", " 3 r/");
-        parseAndAssertHint(editCommandHint, "", "remark", "edit 3 t/");
+        assertHintContent(editCommandHint, "", "remark", "edit 3 t/");
 
         //exhausted all prefix
         editCommandHint = new EditCommandHint("edit 2 n/nicholas p/321 e/email@e.com a/address t/tag r/remark",
                 " 2 n/nicholas p/321 e/email@e.com a/address t/tag r/remark");
-        parseAndAssertHint(editCommandHint, " ", "", "edit 2 n/nicholas p/321 e/email@e.com a/address t/tag r/remark ");
+        assertHintContent(editCommandHint, " ", "", "edit 2 n/nicholas p/321 e/email@e.com a/address t/tag r/remark ");
     }
 
 

--- a/src/test/java/seedu/address/logic/hints/FindCommandHintTest.java
+++ b/src/test/java/seedu/address/logic/hints/FindCommandHintTest.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.hints;
 
-import static seedu.address.logic.hints.AddCommandHintTest.parseAndAssertHint;
+import static seedu.address.logic.hints.AddCommandHintTest.assertHintContent;
 
 import org.junit.Test;
 
@@ -12,31 +12,31 @@ public class FindCommandHintTest {
     public void parseTest() {
         //offer hint
         FindCommandHint findCommandHint = new FindCommandHint("find", "");
-        parseAndAssertHint(findCommandHint, " n/", "name", "find n/");
+        assertHintContent(findCommandHint, " n/", "name", "find n/");
         findCommandHint = new FindCommandHint("find n/ ", " n/ ");
-        parseAndAssertHint(findCommandHint, "p/", "phone", "find n/ p/");
+        assertHintContent(findCommandHint, "p/", "phone", "find n/ p/");
         findCommandHint = new FindCommandHint("find n/nicholas p/321 e/email@e.com a/address",
                 " n/nicholas p/321 e/email@e.com a/address");
-        parseAndAssertHint(findCommandHint, " r/", "remark",
+        assertHintContent(findCommandHint, " r/", "remark",
                 "find n/nicholas p/321 e/email@e.com a/address r/");
         //prefix completion
         findCommandHint = new FindCommandHint("find n", " n");
-        parseAndAssertHint(findCommandHint, "/", "name", "find n/");
+        assertHintContent(findCommandHint, "/", "name", "find n/");
 
         findCommandHint = new FindCommandHint("find p", " p");
-        parseAndAssertHint(findCommandHint, "/", "phone", "find p/");
+        assertHintContent(findCommandHint, "/", "phone", "find p/");
         findCommandHint = new FindCommandHint("find e", " e");
-        parseAndAssertHint(findCommandHint, "/", "email", "find e/");
+        assertHintContent(findCommandHint, "/", "email", "find e/");
 
         //prefix cycle
         findCommandHint = new FindCommandHint("find r/", " r/");
-        parseAndAssertHint(findCommandHint, "", "remark", "find t/");
+        assertHintContent(findCommandHint, "", "remark", "find t/");
         findCommandHint = new FindCommandHint("find a/", " a/");
-        parseAndAssertHint(findCommandHint, "", "address", "find r/");
+        assertHintContent(findCommandHint, "", "address", "find r/");
 
         //exhausted all prefix
         findCommandHint = new FindCommandHint("find n/nicholas p/321 e/email@e.com a/address t/tag r/remark",
                 " n/nicholas p/321 e/email@e.com a/address t/tag r/remark");
-        parseAndAssertHint(findCommandHint, " ", "", "find n/nicholas p/321 e/email@e.com a/address t/tag r/remark ");
+        assertHintContent(findCommandHint, " ", "", "find n/nicholas p/321 e/email@e.com a/address t/tag r/remark ");
     }
 }

--- a/src/test/java/seedu/address/logic/hints/MusicCommandHintTest.java
+++ b/src/test/java/seedu/address/logic/hints/MusicCommandHintTest.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.hints;
 
-import static seedu.address.logic.hints.AddCommandHintTest.parseAndAssertHint;
+import static seedu.address.logic.hints.AddCommandHintTest.assertHintContent;
 
 import org.junit.Test;
 
@@ -16,55 +16,55 @@ public class MusicCommandHintTest {
         MusicCommandHint musicCommandHint;
         if (!MusicCommand.isMusicPlaying()) {
             musicCommandHint = new MusicCommandHint("music", "");
-            parseAndAssertHint(musicCommandHint,
+            assertHintContent(musicCommandHint,
                     " play",
                     " plays music",
                     "music play");
 
             musicCommandHint = new MusicCommandHint("music ", "");
-            parseAndAssertHint(musicCommandHint,
+            assertHintContent(musicCommandHint,
                     "play",
                     " plays music",
                     "music play");
 
             musicCommandHint = new MusicCommandHint("music p", " p");
-            parseAndAssertHint(musicCommandHint,
+            assertHintContent(musicCommandHint,
                     "lay",
                     " plays music",
                     "music play");
 
             musicCommandHint = new MusicCommandHint("music play po", " play po");
-            parseAndAssertHint(musicCommandHint,
+            assertHintContent(musicCommandHint,
                     "p",
                     " plays pop",
                     "music play pop");
         } else {
             musicCommandHint = new MusicCommandHint("music", "");
-            parseAndAssertHint(musicCommandHint,
+            assertHintContent(musicCommandHint,
                     " stop",
                     " stops music",
                     "music stop");
 
             musicCommandHint = new MusicCommandHint("music ", " ");
-            parseAndAssertHint(musicCommandHint,
+            assertHintContent(musicCommandHint,
                     "stop",
                     " stops music",
                     "music stop");
 
             musicCommandHint = new MusicCommandHint("music s", " s");
-            parseAndAssertHint(musicCommandHint,
+            assertHintContent(musicCommandHint,
                     "top",
                     " stops music",
                     "music stop");
 
             musicCommandHint = new MusicCommandHint("music p", " p");
-            parseAndAssertHint(musicCommandHint,
+            assertHintContent(musicCommandHint,
                     "lay",
                     " plays music",
                     "music stop");
 
             musicCommandHint = new MusicCommandHint("music play po", " play po");
-            parseAndAssertHint(musicCommandHint,
+            assertHintContent(musicCommandHint,
                     "p",
                     " plays pop",
                     "music stop ");
@@ -72,38 +72,38 @@ public class MusicCommandHintTest {
 
 
         musicCommandHint = new MusicCommandHint("music play", " play");
-        parseAndAssertHint(musicCommandHint,
+        assertHintContent(musicCommandHint,
                 " pop",
                 " plays pop",
                 "music play pop");
 
         musicCommandHint = new MusicCommandHint("music play pop", " play pop");
-        parseAndAssertHint(musicCommandHint,
+        assertHintContent(musicCommandHint,
                 "",
                 " plays pop",
                 "music play dance");
 
         musicCommandHint = new MusicCommandHint("music play dance", " play dance");
-        parseAndAssertHint(musicCommandHint,
+        assertHintContent(musicCommandHint,
                 "",
                 " plays dance tracks",
                 "music play classic");
 
         musicCommandHint = new MusicCommandHint("music play classic", " play classic");
-        parseAndAssertHint(musicCommandHint,
+        assertHintContent(musicCommandHint,
                 "",
                 " plays the classics",
                 "music play pop");
 
         musicCommandHint = new MusicCommandHint("music play s", " play s");
-        parseAndAssertHint(musicCommandHint,
+        assertHintContent(musicCommandHint,
                 " pop",
                 " plays pop",
                 "music play pop");
 
 
         musicCommandHint = new MusicCommandHint("music stop", " stop");
-        parseAndAssertHint(musicCommandHint,
+        assertHintContent(musicCommandHint,
                 "",
                 " stops music",
                 "music stop");

--- a/src/test/java/seedu/address/logic/hints/NoArgumentsHintTest.java
+++ b/src/test/java/seedu/address/logic/hints/NoArgumentsHintTest.java
@@ -101,7 +101,6 @@ public class NoArgumentsHintTest {
 
 
     private void assertNoArgHint(NoArgumentsHint noArgumentsHint, String description, String autocomplete) {
-        noArgumentsHint.parse();
         assertEquals(description, noArgumentsHint.getDescription());
         assertEquals(autocomplete, noArgumentsHint.autocomplete());
     }

--- a/src/test/java/seedu/address/logic/hints/RadioCommandHintTest.java
+++ b/src/test/java/seedu/address/logic/hints/RadioCommandHintTest.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.hints;
 
-import static seedu.address.logic.hints.AddCommandHintTest.parseAndAssertHint;
+import static seedu.address.logic.hints.AddCommandHintTest.assertHintContent;
 
 import org.junit.Test;
 
@@ -15,87 +15,87 @@ public class RadioCommandHintTest {
         RadioCommand.stopRadioPlayer();
         RadioCommandHint radioCommandHint = new RadioCommandHint("radio", "");
         if (!RadioCommand.isRadioPlaying()) {
-            parseAndAssertHint(radioCommandHint,
+            assertHintContent(radioCommandHint,
                     " play",
                     " plays radio",
                     "radio play");
 
             radioCommandHint = new RadioCommandHint("radio ", "");
-            parseAndAssertHint(radioCommandHint,
+            assertHintContent(radioCommandHint,
                     "play",
                     " plays radio",
                     "radio play");
 
             radioCommandHint = new RadioCommandHint("radio p", " p");
-            parseAndAssertHint(radioCommandHint,
+            assertHintContent(radioCommandHint,
                     "lay",
                     " plays radio",
                     "radio play");
 
             radioCommandHint = new RadioCommandHint("radio sto", " sto");
-            parseAndAssertHint(radioCommandHint,
+            assertHintContent(radioCommandHint,
                     "p",
                     " stops radio",
                     "radio play");
 
             radioCommandHint = new RadioCommandHint("radio play", " play");
-            parseAndAssertHint(radioCommandHint,
+            assertHintContent(radioCommandHint,
                     " pop",
                     " plays pop radio",
                     "radio play pop");
 
             radioCommandHint = new RadioCommandHint("radio play po", " play po");
-            parseAndAssertHint(radioCommandHint,
+            assertHintContent(radioCommandHint,
                     "p",
                     " plays pop radio",
                     "radio play pop");
 
             radioCommandHint = new RadioCommandHint("radio play c", " play c");
-            parseAndAssertHint(radioCommandHint,
+            assertHintContent(radioCommandHint,
                     "hinese",
                     " plays chinese radio",
                     "radio play chinese");
 
 
         } else {
-            parseAndAssertHint(radioCommandHint,
+            assertHintContent(radioCommandHint,
                     " stop",
                     " stops radio",
                     "radio stop");
 
             radioCommandHint = new RadioCommandHint("radio ", "");
-            parseAndAssertHint(radioCommandHint,
+            assertHintContent(radioCommandHint,
                     "stop",
                     " stops radio",
                     "radio stop");
 
             radioCommandHint = new RadioCommandHint("radio s", " s");
-            parseAndAssertHint(radioCommandHint,
+            assertHintContent(radioCommandHint,
                     "top",
                     " stops radio",
                     "radio stop");
 
             radioCommandHint = new RadioCommandHint("radio pla", " pla");
-            parseAndAssertHint(radioCommandHint,
+            assertHintContent(radioCommandHint,
                     "y",
                     " plays radio",
                     "radio stop");
 
             radioCommandHint = new RadioCommandHint("radio play", " play");
-            parseAndAssertHint(radioCommandHint,
+            assertHintContent(radioCommandHint,
                     " pop",
                     " plays pop radio",
                     "radio play pop");
 
 
             radioCommandHint = new RadioCommandHint("radio play po", " play po");
-            parseAndAssertHint(radioCommandHint,
+            assertHintContent(radioCommandHint,
                     "p",
                     " plays pop radio",
                     "radio stop");
 
             radioCommandHint = new RadioCommandHint("radio play c", " play c");
-            parseAndAssertHint(radioCommandHint,
+            assertHintContent(radioCommandHint,
                     "hinese",
                     " plays chinese radio",
                     "radio stop");
@@ -103,37 +103,37 @@ public class RadioCommandHintTest {
 
 
         radioCommandHint = new RadioCommandHint("radio play pop", " play pop");
-        parseAndAssertHint(radioCommandHint,
+        assertHintContent(radioCommandHint,
                 "",
                 " plays pop radio",
                 "radio play chinese");
 
         radioCommandHint = new RadioCommandHint("radio play chinese", " play chinese");
-        parseAndAssertHint(radioCommandHint,
+        assertHintContent(radioCommandHint,
                 "",
                 " plays chinese radio",
                 "radio play classic");
 
         radioCommandHint = new RadioCommandHint("radio play classic", " play classic");
-        parseAndAssertHint(radioCommandHint,
+        assertHintContent(radioCommandHint,
                 "",
                 " plays classic radio",
                 "radio play news");
 
         radioCommandHint = new RadioCommandHint("radio play news", " play news");
-        parseAndAssertHint(radioCommandHint,
+        assertHintContent(radioCommandHint,
                 "",
                 " plays news radio",
                 "radio play pop");
 
         radioCommandHint = new RadioCommandHint("radio play s", " play s");
-        parseAndAssertHint(radioCommandHint,
+        assertHintContent(radioCommandHint,
                 " pop",
                 " plays pop radio",
                 "radio play pop");
 
         radioCommandHint = new RadioCommandHint("radio stop", " stop");
-        parseAndAssertHint(radioCommandHint,
+        assertHintContent(radioCommandHint,
                 "",
                 " stops radio",
                 "radio stop");

--- a/src/test/java/seedu/address/logic/hints/ShareCommandHintTest.java
+++ b/src/test/java/seedu/address/logic/hints/ShareCommandHintTest.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.hints;
 
-import static seedu.address.logic.hints.AddCommandHintTest.parseAndAssertHint;
+import static seedu.address.logic.hints.AddCommandHintTest.assertHintContent;
 
 import org.junit.Test;
 
@@ -11,63 +11,63 @@ public class ShareCommandHintTest {
     @Test
     public void shareCommandHint() {
         ShareCommandHint shareCommandHint = new ShareCommandHint("share", "");
-        parseAndAssertHint(
+        assertHintContent(
                 shareCommandHint,
                 " 1",
                 " index",
                 "share 1");
 
         shareCommandHint = new ShareCommandHint("share ", "");
-        parseAndAssertHint(
+        assertHintContent(
                 shareCommandHint,
                 "1",
                 " index",
                 "share 1");
 
         shareCommandHint = new ShareCommandHint("share 1", " 1");
-        parseAndAssertHint(
+        assertHintContent(
                 shareCommandHint,
                 "",
                 " index",
                 "share 2");
 
         shareCommandHint = new ShareCommandHint("share 1 ", " 1");
-        parseAndAssertHint(
+        assertHintContent(
                 shareCommandHint,
                 "s/",
                 "email or index",
                 "share 1 s/");
 
         shareCommandHint = new ShareCommandHint("share 1 s", " 1 s");
-        parseAndAssertHint(
+        assertHintContent(
                 shareCommandHint,
                 "/",
                 "email or index",
                 "share 1 s/");
 
         shareCommandHint = new ShareCommandHint("share 1 s/", " 1 s/");
-        parseAndAssertHint(
+        assertHintContent(
                 shareCommandHint,
                 "",
                 "email or index",
                 "share 1 s/");
 
         shareCommandHint = new ShareCommandHint("share 1 s/s", " 1 s/s");
-        parseAndAssertHint(
+        assertHintContent(
                 shareCommandHint,
                 " ",
                 "next email or index",
                 "share 1 s/s ");
 
         shareCommandHint = new ShareCommandHint("share 1 s/s ", " 1 s/s ");
-        parseAndAssertHint(
+        assertHintContent(
                 shareCommandHint,
                 "",
                 "next email or index",
                 "share 1 s/s ");
 
         shareCommandHint = new ShareCommandHint("share 1 s/s s", " 1 s/s s");
-        parseAndAssertHint(
+        assertHintContent(
                 shareCommandHint,
                 " ",
                 "next email or index",

--- a/src/test/java/seedu/address/logic/hints/UnaliasCommandHintTest.java
+++ b/src/test/java/seedu/address/logic/hints/UnaliasCommandHintTest.java
@@ -9,26 +9,26 @@ public class UnaliasCommandHintTest {
     @Test
     public void unaliasCommandHint() {
         UnaliasCommandHint unaliasCommandHint = new UnaliasCommandHint("unalias", "");
-        parseAndAssertHint(
+        assertHint(
                 unaliasCommandHint,
                 " removes alias",
                 "unalias ");
 
         unaliasCommandHint = new UnaliasCommandHint("alias ", "");
-        parseAndAssertHint(
+        assertHint(
                 unaliasCommandHint,
                 " alias to remove",
                 "alias ");
 
         unaliasCommandHint = new UnaliasCommandHint("alias s", " s");
-        parseAndAssertHint(
+        assertHint(
                 unaliasCommandHint,
                 " removes s from aliases",
                 "alias s ");
 
 
         unaliasCommandHint = new UnaliasCommandHint("alias aaa ", " aaa ");
-        parseAndAssertHint(
+        assertHint(
                 unaliasCommandHint,
                 " removes aaa from aliases",
                 "alias aaa ");
@@ -38,10 +38,10 @@ public class UnaliasCommandHintTest {
     /**
      * parses {@code unaliasCommandHint} and checks if the the hint generated has the expected fields
      */
-    private void parseAndAssertHint(UnaliasCommandHint unaliasCommandHint,
-                                    String expectedDesc,
-                                    String expectedAutocomplete) {
-        AddCommandHintTest.parseAndAssertHint(
+    private void assertHint(UnaliasCommandHint unaliasCommandHint,
+                            String expectedDesc,
+                            String expectedAutocomplete) {
+        AddCommandHintTest.assertHintContent(
                 unaliasCommandHint,
                 "",
                 expectedDesc,


### PR DESCRIPTION
Resolves bug where `ad |` auto completes to `ad d|`

Refactor hints such that `parse()` need not be called to parse hints. Hints are assumed to be parsed on construction. We assert this with `requiredFIeldsNonNull()` .